### PR TITLE
Remove downstream channel in noncancellable context

### DIFF
--- a/multicast/api/multicast.api
+++ b/multicast/api/multicast.api
@@ -1,10 +1,7 @@
-public final class com/dropbox/flow/multicast/ChannelManager {
-	public fun <init> (Lkotlinx/coroutines/CoroutineScope;IZZLkotlin/jvm/functions/Function2;Lkotlinx/coroutines/flow/Flow;)V
-	public synthetic fun <init> (Lkotlinx/coroutines/CoroutineScope;IZZLkotlin/jvm/functions/Function2;Lkotlinx/coroutines/flow/Flow;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun addDownstream (Lkotlinx/coroutines/channels/SendChannel;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun addDownstream$default (Lcom/dropbox/flow/multicast/ChannelManager;Lkotlinx/coroutines/channels/SendChannel;ZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun close (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun removeDownstream (Lkotlinx/coroutines/channels/SendChannel;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+public abstract interface class com/dropbox/flow/multicast/ChannelManager {
+	public abstract fun addDownstream (Lkotlinx/coroutines/channels/SendChannel;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun close (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun removeDownstream (Lkotlinx/coroutines/channels/SendChannel;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class com/dropbox/flow/multicast/ChannelManager$ChannelEntry {
@@ -23,6 +20,10 @@ public final class com/dropbox/flow/multicast/ChannelManager$ChannelEntry {
 	public final fun hasChannel (Lkotlinx/coroutines/channels/SendChannel;)Z
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/dropbox/flow/multicast/ChannelManager$DefaultImpls {
+	public static synthetic fun addDownstream$default (Lcom/dropbox/flow/multicast/ChannelManager;Lkotlinx/coroutines/channels/SendChannel;ZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public abstract class com/dropbox/flow/multicast/ChannelManager$Message {
@@ -67,8 +68,10 @@ public final class com/dropbox/flow/multicast/Multicaster {
 	public fun <init> (Lkotlinx/coroutines/CoroutineScope;ILkotlinx/coroutines/flow/Flow;ZZLkotlin/jvm/functions/Function2;)V
 	public synthetic fun <init> (Lkotlinx/coroutines/CoroutineScope;ILkotlinx/coroutines/flow/Flow;ZZLkotlin/jvm/functions/Function2;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun close (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getChannelManagerFactory$multicast ()Lkotlin/jvm/functions/Function0;
 	public final fun newDownstream (Z)Lkotlinx/coroutines/flow/Flow;
 	public static synthetic fun newDownstream$default (Lcom/dropbox/flow/multicast/Multicaster;ZILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public final fun setChannelManagerFactory$multicast (Lkotlin/jvm/functions/Function0;)V
 }
 
 public final class com/dropbox/flow/multicast/SharedFlowProducer {
@@ -76,6 +79,14 @@ public final class com/dropbox/flow/multicast/SharedFlowProducer {
 	public final fun cancel ()V
 	public final fun cancelAndJoin (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun start ()V
+}
+
+public final class com/dropbox/flow/multicast/StoreChannelManager : com/dropbox/flow/multicast/ChannelManager {
+	public fun <init> (Lkotlinx/coroutines/CoroutineScope;IZZLkotlin/jvm/functions/Function2;Lkotlinx/coroutines/flow/Flow;)V
+	public synthetic fun <init> (Lkotlinx/coroutines/CoroutineScope;IZZLkotlin/jvm/functions/Function2;Lkotlinx/coroutines/flow/Flow;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun addDownstream (Lkotlinx/coroutines/channels/SendChannel;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun close (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun removeDownstream (Lkotlinx/coroutines/channels/SendChannel;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract class com/dropbox/flow/multicast/StoreRealActor {

--- a/multicast/src/main/kotlin/com/dropbox/flow/multicast/ChannelManager.kt
+++ b/multicast/src/main/kotlin/com/dropbox/flow/multicast/ChannelManager.kt
@@ -22,6 +22,108 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.SendChannel
 import kotlinx.coroutines.flow.Flow
 
+internal interface ChannelManager<T> {
+
+    suspend fun addDownstream(
+        channel: SendChannel<Message.Dispatch.Value<T>>,
+        piggybackOnly: Boolean = false
+    )
+
+    suspend fun removeDownstream(channel: SendChannel<Message.Dispatch.Value<T>>)
+
+    suspend fun close()
+
+    /**
+     * Holder for each downstream collector
+     */
+    data class ChannelEntry<T>(
+        /**
+         * The channel used by the collector
+         */
+        private val channel: SendChannel<Message.Dispatch.Value<T>>,
+        /**
+         * Tracking whether this channel is a piggyback only channel that can be closed without ever
+         * receiving a value or error.
+         */
+        val piggybackOnly: Boolean = false
+    ) {
+        private var _awaitsDispatch: Boolean = !piggybackOnly
+
+        val awaitsDispatch
+            get() = _awaitsDispatch
+
+        suspend fun dispatchValue(value: Message.Dispatch.Value<T>) {
+            _awaitsDispatch = false
+            channel.send(value)
+        }
+
+        fun dispatchError(error: Throwable) {
+            _awaitsDispatch = false
+            channel.close(error)
+        }
+
+        fun close() {
+            channel.close()
+        }
+
+        fun hasChannel(channel: SendChannel<Message.Dispatch.Value<T>>) = this.channel === channel
+
+        fun hasChannel(entry: ChannelEntry<T>) = this.channel === entry.channel
+    }
+
+    /**
+     * Messages accepted by the [ChannelManager].
+     */
+    sealed class Message<out T> {
+        /**
+         * Add a new channel, that means a new downstream subscriber
+         */
+        class AddChannel<T>(
+            val channel: SendChannel<Dispatch.Value<T>>,
+            val piggybackOnly: Boolean = false
+        ) : Message<T>()
+
+        /**
+         * Remove a downstream subscriber, that means it completed
+         */
+        class RemoveChannel<T>(val channel: SendChannel<Dispatch.Value<T>>) : Message<T>()
+
+        sealed class Dispatch<out T> : Message<T>() {
+            /**
+             * Upstream dispatched a new value, send it to all downstream items
+             */
+            class Value<out T>(
+                /**
+                 * The value dispatched by the upstream
+                 */
+                val value: T,
+                /**
+                 * Ack that is completed by all receiver. Upstream producer will await this before asking
+                 * for a new value from upstream
+                 */
+                val delivered: CompletableDeferred<Unit>
+            ) : Dispatch<T>()
+
+            /**
+             * Upstream dispatched an error, send it to all downstream items
+             */
+            class Error(
+                /**
+                 * The error sent by the upstream
+                 */
+                val error: Throwable
+            ) : Dispatch<Nothing>()
+
+            class UpstreamFinished<T>(
+                /**
+                 * SharedFlowProducer finished emitting
+                 */
+                val producer: SharedFlowProducer<T>
+            ) : Dispatch<T>()
+        }
+    }
+}
+
 /**
  * Tracks active downstream channels and dispatches incoming upstream values to each of them in
  * parallel. The upstream is suspended after producing a value until at least one of the downstreams
@@ -31,7 +133,7 @@ import kotlinx.coroutines.flow.Flow
  * is no active upstream and there's at least one downstream that has not received a value.
  *
  */
-internal class ChannelManager<T>(
+internal class StoreChannelManager<T>(
     /**
      * The scope in which ChannelManager actor runs
      */
@@ -60,27 +162,27 @@ internal class ChannelManager<T>(
     private val onEach: suspend (T) -> Unit,
 
     private val upstream: Flow<T>
-) {
+) : ChannelManager<T> {
     init {
         require(!keepUpstreamAlive || bufferSize > 0) {
             "Must set bufferSize > 0 if keepUpstreamAlive is enabled"
         }
     }
 
-    suspend fun addDownstream(channel: SendChannel<Message.Dispatch.Value<T>>, piggybackOnly: Boolean = false) =
+    override suspend fun addDownstream(channel: SendChannel<Message.Dispatch.Value<T>>, piggybackOnly: Boolean) =
         actor.send(Message.AddChannel(channel, piggybackOnly))
 
-    suspend fun removeDownstream(channel: SendChannel<Message.Dispatch.Value<T>>) =
+    override suspend fun removeDownstream(channel: SendChannel<Message.Dispatch.Value<T>>) =
         actor.send(Message.RemoveChannel(channel))
 
-    suspend fun close() = actor.close()
+    override suspend fun close() = actor.close()
 
     private val actor = Actor()
 
     /**
      * Actor that does all the work. Any state and functionality should go here.
      */
-    private inner class Actor : StoreRealActor<Message<T>>(scope) {
+    private inner class Actor : StoreRealActor<ChannelManager.Message<T>>(scope) {
 
         private val buffer = Buffer<T>(bufferSize)
 
@@ -106,9 +208,9 @@ internal class ChannelManager<T>(
         /**
          * List of downstream collectors.
          */
-        private val channels = mutableListOf<ChannelEntry<T>>()
+        private val channels = mutableListOf<ChannelManager.ChannelEntry<T>>()
 
-        override suspend fun handle(msg: Message<T>) {
+        override suspend fun handle(msg: ChannelManager.Message<T>) {
             when (msg) {
                 is Message.AddChannel -> doAdd(msg)
                 is Message.RemoveChannel -> doRemove(msg.channel)
@@ -132,8 +234,8 @@ internal class ChannelManager<T>(
             if (this.producer !== producer) {
                 return
             }
-            val piggyBacked = mutableListOf<ChannelEntry<T>>()
-            val leftovers = mutableListOf<ChannelEntry<T>>()
+            val piggyBacked = mutableListOf<ChannelManager.ChannelEntry<T>>()
+            val leftovers = mutableListOf<ChannelManager.ChannelEntry<T>>()
             channels.forEach {
                 when {
                     !it.awaitsDispatch -> {
@@ -225,7 +327,7 @@ internal class ChannelManager<T>(
                 "cannot add a piggyback only downstream when piggybackDownstream is disabled"
             }
             addEntry(
-                entry = ChannelEntry(
+                entry = ChannelManager.ChannelEntry(
                     channel = msg.channel,
                     piggybackOnly = msg.piggybackOnly
                 )
@@ -246,7 +348,7 @@ internal class ChannelManager<T>(
         /**
          * Internally add the new downstream collector to our list, send it anything buffered.
          */
-        private suspend fun addEntry(entry: ChannelEntry<T>) {
+        private suspend fun addEntry(entry: ChannelManager.ChannelEntry<T>) {
             val new = channels.none {
                 it.hasChannel(entry)
             }
@@ -264,116 +366,26 @@ internal class ChannelManager<T>(
             }
         }
     }
-
-    /**
-     * Holder for each downstream collector
-     */
-    internal data class ChannelEntry<T>(
-        /**
-         * The channel used by the collector
-         */
-        private val channel: SendChannel<Message.Dispatch.Value<T>>,
-        /**
-         * Tracking whether this channel is a piggyback only channel that can be closed without ever
-         * receiving a value or error.
-         */
-        val piggybackOnly: Boolean = false
-    ) {
-        private var _awaitsDispatch: Boolean = !piggybackOnly
-
-        val awaitsDispatch
-            get() = _awaitsDispatch
-
-        suspend fun dispatchValue(value: Message.Dispatch.Value<T>) {
-            _awaitsDispatch = false
-            channel.send(value)
-        }
-
-        fun dispatchError(error: Throwable) {
-            _awaitsDispatch = false
-            channel.close(error)
-        }
-
-        fun close() {
-            channel.close()
-        }
-
-        fun hasChannel(channel: SendChannel<Message.Dispatch.Value<T>>) = this.channel === channel
-
-        fun hasChannel(entry: ChannelEntry<T>) = this.channel === entry.channel
-    }
-
-    /**
-     * Messages accepted by the [ChannelManager].
-     */
-    sealed class Message<out T> {
-        /**
-         * Add a new channel, that means a new downstream subscriber
-         */
-        class AddChannel<T>(
-            val channel: SendChannel<Dispatch.Value<T>>,
-            val piggybackOnly: Boolean = false
-        ) : Message<T>()
-
-        /**
-         * Remove a downstream subscriber, that means it completed
-         */
-        class RemoveChannel<T>(val channel: SendChannel<Dispatch.Value<T>>) : Message<T>()
-
-        sealed class Dispatch<out T> : Message<T>() {
-            /**
-             * Upstream dispatched a new value, send it to all downstream items
-             */
-            class Value<out T>(
-                /**
-                 * The value dispatched by the upstream
-                 */
-                val value: T,
-                /**
-                 * Ack that is completed by all receiver. Upstream producer will await this before asking
-                 * for a new value from upstream
-                 */
-                val delivered: CompletableDeferred<Unit>
-            ) : Dispatch<T>()
-
-            /**
-             * Upstream dispatched an error, send it to all downstream items
-             */
-            class Error(
-                /**
-                 * The error sent by the upstream
-                 */
-                val error: Throwable
-            ) : Dispatch<Nothing>()
-
-            class UpstreamFinished<T>(
-                /**
-                 * SharedFlowProducer finished emitting
-                 */
-                val producer: SharedFlowProducer<T>
-            ) : Dispatch<T>()
-        }
-    }
 }
 
 /**
  * Buffer implementation for any late arrivals.
  */
 private interface Buffer<T> {
-    fun add(item: ChannelManager.Message.Dispatch.Value<T>)
+    fun add(item: Message.Dispatch.Value<T>)
     fun isEmpty() = items.isEmpty()
-    val items: Collection<ChannelManager.Message.Dispatch.Value<T>>
+    val items: Collection<Message.Dispatch.Value<T>>
 }
 
 /**
  * Default implementation of buffer which does not buffer anything.
  */
 private class NoBuffer<T> : Buffer<T> {
-    override val items: Collection<ChannelManager.Message.Dispatch.Value<T>>
+    override val items: Collection<Message.Dispatch.Value<T>>
         get() = emptyList()
 
     // ignore
-    override fun add(item: ChannelManager.Message.Dispatch.Value<T>) = Unit
+    override fun add(item: Message.Dispatch.Value<T>) = Unit
 }
 
 /**
@@ -391,8 +403,8 @@ private fun <T> Buffer(limit: Int): Buffer<T> = if (limit > 0) {
  */
 private class BufferImpl<T>(private val limit: Int) :
     Buffer<T> {
-    override val items = ArrayDeque<ChannelManager.Message.Dispatch.Value<T>>(limit.coerceAtMost(10))
-    override fun add(item: ChannelManager.Message.Dispatch.Value<T>) {
+    override val items = ArrayDeque<Message.Dispatch.Value<T>>(limit.coerceAtMost(10))
+    override fun add(item: Message.Dispatch.Value<T>) {
         while (items.size >= limit) {
             items.removeFirst()
         }
@@ -400,5 +412,5 @@ private class BufferImpl<T>(private val limit: Int) :
     }
 }
 
-internal fun <T> ChannelManager.Message.Dispatch.Value<T>.markDelivered() =
+internal fun <T> Message.Dispatch.Value<T>.markDelivered() =
     delivered.complete(Unit)

--- a/multicast/src/test/kotlin/com/dropbox/flow/multicast/ChannelManagerTest.kt
+++ b/multicast/src/test/kotlin/com/dropbox/flow/multicast/ChannelManagerTest.kt
@@ -39,7 +39,7 @@ import kotlin.test.fail
 class ChannelManagerTest {
     private val scope = TestCoroutineScope()
     private val upstream: Channel<String> = Channel(Channel.UNLIMITED)
-    private val manager = ChannelManager(
+    private val manager = StoreChannelManager(
         scope,
         0,
         onEach = {},
@@ -174,7 +174,7 @@ class ChannelManagerTest {
         }
 
         // create a manager with this specific upstream
-        val manager = ChannelManager(
+        val manager = StoreChannelManager(
             scope,
             bufferSize = 1,
             onEach = {},
@@ -336,7 +336,7 @@ class ChannelManagerTest {
         // upstream that tracks creates and can be emitted to on demand
 
         // create a manager with this specific upstream
-        val manager = ChannelManager(
+        val manager = StoreChannelManager(
             scope,
             bufferSize,
             onEach = {},


### PR DESCRIPTION
Fixes #435 

Explanation:
When downstream  flow is  aborted (this is happening when first operator is called on flow -> which is called in Store.fresh extension),  than coroutine context  in which is subflow (created from channel) is cancelling. In this case the channel is cancelled too, but there is no guarantee that channel is properly removed from the channel manager. In the next run when the channel manager is trying to send msg (ChannelManager::doDispatchValue) to this cancelled channel, it throws  AbortFlowException. This exception is caught in StoreRealActor and this caused that all channels(and Multicaster itself) are closed. 