### PR TITLE
Add removal listener + build on local cache module

### DIFF
--- a/cache/api/cache.api
+++ b/cache/api/cache.api
@@ -187,6 +187,7 @@ public abstract interface class com/dropbox/android/external/cache3/RemovalListe
 public final class com/dropbox/android/external/cache3/RemovalNotification : java/util/Map$Entry {
 	public static fun create (Ljava/lang/Object;Ljava/lang/Object;Lcom/dropbox/android/external/cache3/RemovalCause;)Lcom/dropbox/android/external/cache3/RemovalNotification;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getCause ()Lcom/dropbox/android/external/cache3/RemovalCause;
 	public fun getKey ()Ljava/lang/Object;
 	public fun getValue ()Ljava/lang/Object;
 	public fun hashCode ()I

--- a/cache/src/main/java/com/dropbox/android/external/cache3/RemovalNotification.java
+++ b/cache/src/main/java/com/dropbox/android/external/cache3/RemovalNotification.java
@@ -13,7 +13,7 @@ public final class RemovalNotification<K, V> implements Map.Entry<K, V> {
 
   private final K key;
     private final V value;
-  @Nullable
+  @Nonnull
   private final RemovalCause cause;
 
   /**
@@ -53,6 +53,10 @@ public final class RemovalNotification<K, V> implements Map.Entry<K, V> {
 //    return cause.wasEvicted();
 //  }
 // --Commented out by Inspection STOP (11/29/16, 5:04 PM)
+
+    @Nonnull public RemovalCause getCause() {
+    return cause;
+  }
 
     @Override public K getKey() {
     return key;

--- a/store/api/store.api
+++ b/store/api/store.api
@@ -63,7 +63,7 @@ public final class com/dropbox/android/external/store4/FetcherResult$Error$Messa
 public final class com/dropbox/android/external/store4/MemoryPolicy {
 	public static final field Companion Lcom/dropbox/android/external/store4/MemoryPolicy$Companion;
 	public static final field DEFAULT_SIZE_POLICY J
-	public synthetic fun <init> (JJJJLcom/dropbox/android/external/store4/Weigher;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JJJJLcom/dropbox/android/external/store4/Weigher;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getExpireAfterAccess-UwyO8pc ()J
 	public final fun getExpireAfterWrite-UwyO8pc ()J
 	public final fun getHasAccessPolicy ()Z
@@ -72,6 +72,7 @@ public final class com/dropbox/android/external/store4/MemoryPolicy {
 	public final fun getHasWritePolicy ()Z
 	public final fun getMaxSize ()J
 	public final fun getMaxWeight ()J
+	public final fun getRemovalListener ()Lkotlin/jvm/functions/Function3;
 	public final fun getWeigher ()Lcom/dropbox/android/external/store4/Weigher;
 	public final fun isDefaultWritePolicy ()Z
 }
@@ -87,6 +88,7 @@ public final class com/dropbox/android/external/store4/MemoryPolicy$MemoryPolicy
 	public final fun setExpireAfterAccess-LRDsOJo (J)Lcom/dropbox/android/external/store4/MemoryPolicy$MemoryPolicyBuilder;
 	public final fun setExpireAfterWrite-LRDsOJo (J)Lcom/dropbox/android/external/store4/MemoryPolicy$MemoryPolicyBuilder;
 	public final fun setMaxSize (J)Lcom/dropbox/android/external/store4/MemoryPolicy$MemoryPolicyBuilder;
+	public final fun setRemovalListener (Lkotlin/jvm/functions/Function3;)Lcom/dropbox/android/external/store4/MemoryPolicy$MemoryPolicyBuilder;
 	public final fun setWeigherAndMaxWeight (Lcom/dropbox/android/external/store4/Weigher;J)Lcom/dropbox/android/external/store4/MemoryPolicy$MemoryPolicyBuilder;
 }
 

--- a/store/build.gradle
+++ b/store/build.gradle
@@ -14,7 +14,7 @@ plugins {
 }
 
 dependencies {
-    implementation libraries.cache
+    implementation project(path: ':cache')
     implementation project(path: ':multicast')
     implementation libraries.coroutinesCore
 

--- a/store/src/main/java/com/dropbox/android/external/store4/MemoryPolicy.kt
+++ b/store/src/main/java/com/dropbox/android/external/store4/MemoryPolicy.kt
@@ -1,5 +1,6 @@
 package com.dropbox.android.external.store4
 
+import com.dropbox.android.external.cache3.RemovalCause
 import kotlin.time.Duration
 import kotlin.time.ExperimentalTime
 
@@ -34,7 +35,8 @@ class MemoryPolicy<in Key : Any, in Value : Any> internal constructor(
     val expireAfterAccess: Duration,
     val maxSize: Long,
     val maxWeight: Long,
-    val weigher: Weigher<Key, Value>
+    val weigher: Weigher<Key, Value>,
+    val removalListener: ((Key, Value, RemovalCause) -> Unit)?
 ) {
 
     val isDefaultWritePolicy: Boolean = expireAfterWrite == DEFAULT_DURATION_POLICY
@@ -53,6 +55,7 @@ class MemoryPolicy<in Key : Any, in Value : Any> internal constructor(
         private var maxSize: Long = DEFAULT_SIZE_POLICY
         private var maxWeight: Long = DEFAULT_SIZE_POLICY
         private var weigher: Weigher<Key, Value> = OneWeigher
+        private var removalListener: ((Key, Value, RemovalCause) -> Unit)? = null
 
         fun setExpireAfterWrite(expireAfterWrite: Duration): MemoryPolicyBuilder<Key, Value> =
             apply {
@@ -97,12 +100,25 @@ class MemoryPolicy<in Key : Any, in Value : Any> internal constructor(
             this.maxWeight = maxWeight
         }
 
+        /**
+         * Specifies a listener instance that caches should notify each time an entry is removed for
+         * any [com.nytimes.android.external.cache3.RemovalCause]. Each cache created by this builder
+         * will invoke this listener as part of the routine maintenance described in the
+         * class documentation above.
+         */
+        fun setRemovalListener(
+            removalListener: (Key, Value, RemovalCause) -> Unit
+        ): MemoryPolicyBuilder<Key, Value> = apply {
+            this.removalListener = removalListener
+        }
+
         fun build() = MemoryPolicy<Key, Value>(
             expireAfterWrite = expireAfterWrite,
             expireAfterAccess = expireAfterAccess,
             maxSize = maxSize,
             maxWeight = maxWeight,
-            weigher = weigher
+            weigher = weigher,
+            removalListener = removalListener,
         )
     }
 

--- a/store/src/main/java/com/dropbox/android/external/store4/impl/RealStore.kt
+++ b/store/src/main/java/com/dropbox/android/external/store4/impl/RealStore.kt
@@ -15,26 +15,14 @@
  */
 package com.dropbox.android.external.store4.impl
 
-import com.dropbox.android.external.store4.CacheType
-import com.dropbox.android.external.store4.ExperimentalStoreApi
-import com.dropbox.android.external.store4.Fetcher
-import com.dropbox.android.external.store4.MemoryPolicy
-import com.dropbox.android.external.store4.ResponseOrigin
-import com.dropbox.android.external.store4.SourceOfTruth
-import com.dropbox.android.external.store4.Store
-import com.dropbox.android.external.store4.StoreRequest
-import com.dropbox.android.external.store4.StoreResponse
+import com.dropbox.android.external.cache3.CacheBuilder
+import com.dropbox.android.external.cache3.RemovalListener
+import com.dropbox.android.external.store4.*
 import com.dropbox.android.external.store4.impl.operators.Either
 import com.dropbox.android.external.store4.impl.operators.merge
-import com.nytimes.android.external.cache3.CacheBuilder
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.emitAll
-import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.onEach
-import kotlinx.coroutines.flow.onStart
-import kotlinx.coroutines.flow.transform
+import kotlinx.coroutines.flow.*
 import java.util.concurrent.TimeUnit
 import kotlin.time.ExperimentalTime
 
@@ -78,6 +66,11 @@ internal class RealStore<Key : Any, Input : Any, Output : Any>(
             if (memoryPolicy.hasMaxWeight) {
                 maximumWeight(memoryPolicy.maxWeight)
                 weigher { k: Key, v: Output -> memoryPolicy.weigher.weigh(k, v) }
+            }
+            memoryPolicy.removalListener?.let { listener ->
+                removalListener(RemovalListener<Key, Output> {
+                    listener.invoke(it.key, it.value, it.cause)
+                })
             }
         }.build<Key, Output>()
     }

--- a/store/src/test/java/com/dropbox/android/external/store4/impl/StoreWithInMemoryCacheTest.kt
+++ b/store/src/test/java/com/dropbox/android/external/store4/impl/StoreWithInMemoryCacheTest.kt
@@ -1,9 +1,12 @@
 package com.dropbox.android.external.store4.impl
 
+import com.dropbox.android.external.cache3.RemovalCause
 import com.dropbox.android.external.store4.Fetcher
 import com.dropbox.android.external.store4.MemoryPolicy
 import com.dropbox.android.external.store4.StoreBuilder
 import com.dropbox.android.external.store4.get
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.runBlocking
@@ -37,6 +40,30 @@ class StoreWithInMemoryCacheTest {
             store.get(0)
             store.get(1)
             store.get(2)
+        }
+    }
+
+    @Test
+    fun `store requests with removal listener when its in-memory cache is at the maximum size`() {
+        val listenerMock = mock<(Int, String, RemovalCause) -> Unit>()
+        val store = StoreBuilder
+            .from(Fetcher.of { key: Int -> "result_$key" })
+            .cachePolicy(
+                MemoryPolicy
+                    .builder<Int, String>()
+                    .setMaxSize(1)
+                    .setRemovalListener(listenerMock)
+                    .build()
+            )
+            .build()
+
+        runBlocking {
+            store.get(0)
+            store.get(1)
+            store.get(2)
+
+            verify(listenerMock).invoke(0, "result_0", RemovalCause.SIZE)
+            verify(listenerMock).invoke(1, "result_1", RemovalCause.SIZE)
         }
     }
 }


### PR DESCRIPTION
I need to know when an item is remove from the cache, so I add the possibility to put an listener in the `MemoryPolicy` wich be add to the `CacheBuilder` 
There are 2 point where I need your advice 
- I must retrieve the `RemovalCause` in the `RemovalNotification` but actually the project is base on cache3 host on GitHub, not in the local module of cache. We can't make PR on this project it deprecated and in read only. So I have remove this repo and use directly the local code of cache to be able to maintain 
- Actually add the listener will be leak because we must can remove it. But we can't actually with an builder. There is some option to handle it, we must the possibility to clear the listener in the Cache, and after either add an `destroy` function in the `Store` call by the user or use the coroutine scope and catch when an Cancellable are emit to remove the listener 

I'm very interested in hearing your opinions on this. 

