### PR TITLE
Add iOS simulator support for KMM projects

### DIFF
--- a/cache/build.gradle.kts
+++ b/cache/build.gradle.kts
@@ -21,6 +21,7 @@ kotlin {
     jvm()
     iosArm64()
     iosX64()
+    iosSimulatorArm64()
     js {
         browser()
         nodejs()

--- a/multicast/build.gradle.kts
+++ b/multicast/build.gradle.kts
@@ -21,6 +21,7 @@ kotlin {
     jvm()
     iosArm64()
     iosX64()
+    iosSimulatorArm64()
     js {
         browser()
         nodejs()

--- a/store/build.gradle.kts
+++ b/store/build.gradle.kts
@@ -21,6 +21,7 @@ kotlin {
     jvm()
     iosArm64()
     iosX64()
+    iosSimulatorArm64()
     js {
         browser()
         nodejs()


### PR DESCRIPTION
Just adds `iosSimulatorArm64` target to improve KMM support.

Should close #511 