### PR TITLE
Remove KMM Bridge From Cache and Multicast

### DIFF
--- a/cache/build.gradle.kts
+++ b/cache/build.gradle.kts
@@ -10,7 +10,6 @@ plugins {
     id("com.vanniktech.maven.publish")
     id("org.jetbrains.dokka")
     id("org.jetbrains.kotlinx.kover")
-    id("co.touchlab.faktory.kmmbridge") version Version.kmmBridge
     `maven-publish`
     kotlin("native.cocoapods")
     id("kotlinx-atomicfu")
@@ -89,14 +88,6 @@ tasks.withType<DokkaTask>().configureEach {
 mavenPublishing {
     publishToMavenCentral(S01)
     signAllPublications()
-}
-
-addGithubPackagesRepository()
-kmmbridge {
-    githubReleaseArtifacts()
-    githubReleaseVersions()
-    versionPrefix.set("5.0.0-alpha")
-    spm()
 }
 
 koverMerged {

--- a/multicast/build.gradle.kts
+++ b/multicast/build.gradle.kts
@@ -10,7 +10,6 @@ plugins {
     id("com.vanniktech.maven.publish")
     id("org.jetbrains.dokka")
     id("org.jetbrains.kotlinx.kover")
-    id("co.touchlab.faktory.kmmbridge") version Version.kmmBridge
     `maven-publish`
     kotlin("native.cocoapods")
     id("kotlinx-atomicfu")
@@ -90,14 +89,6 @@ tasks.withType<DokkaTask>().configureEach {
 mavenPublishing {
     publishToMavenCentral(S01)
     signAllPublications()
-}
-
-addGithubPackagesRepository()
-kmmbridge {
-    githubReleaseArtifacts()
-    githubReleaseVersions()
-    versionPrefix.set("5.0.0-alpha")
-    spm()
 }
 
 koverMerged {


### PR DESCRIPTION
Currently KMM Bridge only supports one module per repo. Removing KMM Bridge plugins from `cache` and `multicast` modules. This means our workflow will only generate a Swift package for `store`. For full context, see: https://kotlinlang.slack.com/archives/CTJB58X7X/p1677961467532679.