### PR TITLE
Separate MutableStoreBuilder from StoreBuilder

### DIFF
--- a/store/src/commonMain/kotlin/org/mobilenativefoundation/store/store5/MutableStoreBuilder.kt
+++ b/store/src/commonMain/kotlin/org/mobilenativefoundation/store/store5/MutableStoreBuilder.kt
@@ -32,7 +32,7 @@ interface MutableStoreBuilder<Key : Any, Network : Any, Output : Any, Local : An
     fun disableCache(): MutableStoreBuilder<Key, Network, Output, Local>
 
     fun converter(converter: Converter<Network, Output, Local>):
-            MutableStoreBuilder<Key, Network, Output, Local>
+        MutableStoreBuilder<Key, Network, Output, Local>
 
     fun validator(validator: Validator<Output>): MutableStoreBuilder<Key, Network, Output, Local>
 

--- a/store/src/commonMain/kotlin/org/mobilenativefoundation/store/store5/MutableStoreBuilder.kt
+++ b/store/src/commonMain/kotlin/org/mobilenativefoundation/store/store5/MutableStoreBuilder.kt
@@ -1,0 +1,52 @@
+package org.mobilenativefoundation.store.store5
+
+import kotlinx.coroutines.CoroutineScope
+import org.mobilenativefoundation.store.store5.impl.mutableStoreBuilderFromFetcherAndSourceOfTruth
+
+interface MutableStoreBuilder<Key : Any, Network : Any, Output : Any, Local : Any> {
+
+    fun <Response : Any> build(
+        updater: Updater<Key, Output, Response>,
+        bookkeeper: Bookkeeper<Key>? = null
+    ): MutableStore<Key, Output>
+
+    /**
+     * A store multicasts same [Output] value to many consumers (Similar to RxJava.share()), by default
+     *  [Store] will open a global scope for management of shared responses, if instead you'd like to control
+     *  the scope that sharing/multicasting happens in you can pass a @param [scope]
+     *
+     *   @param scope - scope to use for sharing
+     */
+    fun scope(scope: CoroutineScope): MutableStoreBuilder<Key, Network, Output, Local>
+
+    /**
+     * controls eviction policy for a store cache, use [MemoryPolicy.MemoryPolicyBuilder] to configure a TTL
+     *  or size based eviction
+     *  Example: MemoryPolicy.builder().setExpireAfterWrite(10.seconds).build()
+     */
+    fun cachePolicy(memoryPolicy: MemoryPolicy<Key, Output>?): MutableStoreBuilder<Key, Network, Output, Local>
+
+    /**
+     * by default a Store caches in memory with a default policy of max items = 100
+     */
+    fun disableCache(): MutableStoreBuilder<Key, Network, Output, Local>
+
+    fun converter(converter: Converter<Network, Output, Local>):
+            MutableStoreBuilder<Key, Network, Output, Local>
+
+    fun validator(validator: Validator<Output>): MutableStoreBuilder<Key, Network, Output, Local>
+
+    companion object {
+        /**
+         * Creates a new [MutableStoreBuilder] from a [Fetcher] and a [SourceOfTruth].
+         *
+         * @param fetcher a function for fetching a flow of network records.
+         * @param sourceOfTruth a [SourceOfTruth] for the store.
+         */
+        fun <Key : Any, Network : Any, Output : Any> from(
+            fetcher: Fetcher<Key, Network>,
+            sourceOfTruth: SourceOfTruth<Key, Output>
+        ): MutableStoreBuilder<Key, Network, Output, Output> =
+            mutableStoreBuilderFromFetcherAndSourceOfTruth(fetcher = fetcher, sourceOfTruth = sourceOfTruth)
+    }
+}

--- a/store/src/commonMain/kotlin/org/mobilenativefoundation/store/store5/MutableStoreBuilder.kt
+++ b/store/src/commonMain/kotlin/org/mobilenativefoundation/store/store5/MutableStoreBuilder.kt
@@ -43,10 +43,10 @@ interface MutableStoreBuilder<Key : Any, Network : Any, Output : Any, Local : An
          * @param fetcher a function for fetching a flow of network records.
          * @param sourceOfTruth a [SourceOfTruth] for the store.
          */
-        fun <Key : Any, Network : Any, Output : Any> from(
+        fun <Key : Any, Network : Any, Output : Any, Local : Any> from(
             fetcher: Fetcher<Key, Network>,
-            sourceOfTruth: SourceOfTruth<Key, Output>
-        ): MutableStoreBuilder<Key, Network, Output, Output> =
+            sourceOfTruth: SourceOfTruth<Key, Local>
+        ): MutableStoreBuilder<Key, Network, Output, Local> =
             mutableStoreBuilderFromFetcherAndSourceOfTruth(fetcher = fetcher, sourceOfTruth = sourceOfTruth)
     }
 }

--- a/store/src/commonMain/kotlin/org/mobilenativefoundation/store/store5/StoreBuilder.kt
+++ b/store/src/commonMain/kotlin/org/mobilenativefoundation/store/store5/StoreBuilder.kt
@@ -25,7 +25,6 @@ import org.mobilenativefoundation.store.store5.impl.storeBuilderFromFetcherAndSo
 interface StoreBuilder<Key : Any, Output : Any> {
     fun build(): Store<Key, Output>
 
-
     fun <Network : Any, Local : Any> toMutableStoreBuilder(): MutableStoreBuilder<Key, Network, Output, Local>
 
     /**
@@ -73,5 +72,3 @@ interface StoreBuilder<Key : Any, Output : Any> {
         ): StoreBuilder<Key, Output> = storeBuilderFromFetcherAndSourceOfTruth(fetcher = fetcher, sourceOfTruth = sourceOfTruth)
     }
 }
-
-

--- a/store/src/commonMain/kotlin/org/mobilenativefoundation/store/store5/StoreBuilder.kt
+++ b/store/src/commonMain/kotlin/org/mobilenativefoundation/store/store5/StoreBuilder.kt
@@ -22,13 +22,8 @@ import org.mobilenativefoundation.store.store5.impl.storeBuilderFromFetcherAndSo
 /**
  * Main entry point for creating a [Store].
  */
-interface StoreBuilder<Key : Any, Network : Any, Output : Any, Local : Any> {
+interface StoreBuilder<Key : Any, Output : Any> {
     fun build(): Store<Key, Output>
-
-    fun <Response : Any> build(
-        updater: Updater<Key, Output, Response>,
-        bookkeeper: Bookkeeper<Key>? = null
-    ): MutableStore<Key, Output>
 
     /**
      * A store multicasts same [Output] value to many consumers (Similar to RxJava.share()), by default
@@ -37,35 +32,31 @@ interface StoreBuilder<Key : Any, Network : Any, Output : Any, Local : Any> {
      *
      *   @param scope - scope to use for sharing
      */
-    fun scope(scope: CoroutineScope): StoreBuilder<Key, Network, Output, Local>
+    fun scope(scope: CoroutineScope): StoreBuilder<Key, Output>
 
     /**
      * controls eviction policy for a store cache, use [MemoryPolicy.MemoryPolicyBuilder] to configure a TTL
      *  or size based eviction
      *  Example: MemoryPolicy.builder().setExpireAfterWrite(10.seconds).build()
      */
-    fun cachePolicy(memoryPolicy: MemoryPolicy<Key, Output>?): StoreBuilder<Key, Network, Output, Local>
+    fun cachePolicy(memoryPolicy: MemoryPolicy<Key, Output>?): StoreBuilder<Key, Output>
 
     /**
      * by default a Store caches in memory with a default policy of max items = 100
      */
-    fun disableCache(): StoreBuilder<Key, Network, Output, Local>
+    fun disableCache(): StoreBuilder<Key, Output>
 
-    fun converter(converter: Converter<Network, Output, Local>):
-        StoreBuilder<Key, Network, Output, Local>
-
-    fun validator(validator: Validator<Output>): StoreBuilder<Key, Network, Output, Local>
+    fun validator(validator: Validator<Output>): StoreBuilder<Key, Output>
 
     companion object {
-
         /**
          * Creates a new [StoreBuilder] from a [Fetcher].
          *
          * @param fetcher a [Fetcher] flow of network records.
          */
-        fun <Key : Any, Network : Any, Output : Any> from(
-            fetcher: Fetcher<Key, Network>,
-        ): StoreBuilder<Key, Network, Output, *> = storeBuilderFromFetcher(fetcher = fetcher)
+        fun <Key : Any, Input : Any, Output : Any> from(
+            fetcher: Fetcher<Key, Input>,
+        ): StoreBuilder<Key, Output> = storeBuilderFromFetcher(fetcher = fetcher)
 
         /**
          * Creates a new [StoreBuilder] from a [Fetcher] and a [SourceOfTruth].
@@ -73,10 +64,11 @@ interface StoreBuilder<Key : Any, Network : Any, Output : Any, Local : Any> {
          * @param fetcher a function for fetching a flow of network records.
          * @param sourceOfTruth a [SourceOfTruth] for the store.
          */
-        fun <Key : Any, Network : Any, Output : Any, Local : Any> from(
-            fetcher: Fetcher<Key, Network>,
-            sourceOfTruth: SourceOfTruth<Key, Local>
-        ): StoreBuilder<Key, Network, Output, Local> =
-            storeBuilderFromFetcherAndSourceOfTruth(fetcher = fetcher, sourceOfTruth = sourceOfTruth)
+        fun <Key : Any, Input : Any, Output : Any> from(
+            fetcher: Fetcher<Key, Input>,
+            sourceOfTruth: SourceOfTruth<Key, Input>
+        ): StoreBuilder<Key, Output> = storeBuilderFromFetcherAndSourceOfTruth(fetcher = fetcher, sourceOfTruth = sourceOfTruth)
     }
 }
+
+

--- a/store/src/commonMain/kotlin/org/mobilenativefoundation/store/store5/StoreBuilder.kt
+++ b/store/src/commonMain/kotlin/org/mobilenativefoundation/store/store5/StoreBuilder.kt
@@ -25,6 +25,9 @@ import org.mobilenativefoundation.store.store5.impl.storeBuilderFromFetcherAndSo
 interface StoreBuilder<Key : Any, Output : Any> {
     fun build(): Store<Key, Output>
 
+
+    fun <Network : Any, Local : Any> toMutableStoreBuilder(): MutableStoreBuilder<Key, Network, Output, Local>
+
     /**
      * A store multicasts same [Output] value to many consumers (Similar to RxJava.share()), by default
      *  [Store] will open a global scope for management of shared responses, if instead you'd like to control

--- a/store/src/commonMain/kotlin/org/mobilenativefoundation/store/store5/impl/RealMutableStoreBuilder.kt
+++ b/store/src/commonMain/kotlin/org/mobilenativefoundation/store/store5/impl/RealMutableStoreBuilder.kt
@@ -15,11 +15,9 @@ import org.mobilenativefoundation.store.store5.Updater
 import org.mobilenativefoundation.store.store5.Validator
 import org.mobilenativefoundation.store.store5.impl.extensions.asMutableStore
 
-
 fun <Key : Any, Network : Any, Output : Any, Local : Any> mutableStoreBuilderFromFetcher(
     fetcher: Fetcher<Key, Network>,
 ): MutableStoreBuilder<Key, Network, Output, Local> = RealMutableStoreBuilder(fetcher)
-
 
 fun <Key : Any, Network : Any, Output : Any, Local : Any> mutableStoreBuilderFromFetcherAndSourceOfTruth(
     fetcher: Fetcher<Key, Network>,

--- a/store/src/commonMain/kotlin/org/mobilenativefoundation/store/store5/impl/RealMutableStoreBuilder.kt
+++ b/store/src/commonMain/kotlin/org/mobilenativefoundation/store/store5/impl/RealMutableStoreBuilder.kt
@@ -1,0 +1,76 @@
+package org.mobilenativefoundation.store.store5.impl
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.GlobalScope
+import org.mobilenativefoundation.store.store5.Bookkeeper
+import org.mobilenativefoundation.store.store5.Converter
+import org.mobilenativefoundation.store.store5.Fetcher
+import org.mobilenativefoundation.store.store5.MemoryPolicy
+import org.mobilenativefoundation.store.store5.MutableStore
+import org.mobilenativefoundation.store.store5.MutableStoreBuilder
+import org.mobilenativefoundation.store.store5.SourceOfTruth
+import org.mobilenativefoundation.store.store5.Store
+import org.mobilenativefoundation.store.store5.StoreDefaults
+import org.mobilenativefoundation.store.store5.Updater
+import org.mobilenativefoundation.store.store5.Validator
+import org.mobilenativefoundation.store.store5.impl.extensions.asMutableStore
+
+
+fun <Key : Any, Output : Any, Network : Any, Local : Any> mutableStoreBuilderFromFetcherAndSourceOfTruth(
+    fetcher: Fetcher<Key, Network>,
+    sourceOfTruth: SourceOfTruth<Key, Local>,
+): MutableStoreBuilder<Key, Network, Output, Local> = RealMutableStoreBuilder(fetcher, sourceOfTruth)
+
+
+internal class RealMutableStoreBuilder<Key : Any, Network : Any, Output : Any, Local : Any>(
+    private val fetcher: Fetcher<Key, Network>,
+    private val sourceOfTruth: SourceOfTruth<Key, Local>? = null,
+) : MutableStoreBuilder<Key, Network, Output, Local> {
+    private var scope: CoroutineScope? = null
+    private var cachePolicy: MemoryPolicy<Key, Output>? = StoreDefaults.memoryPolicy
+    private var converter: Converter<Network, Output, Local>? = null
+    private var validator: Validator<Output>? = null
+
+    override fun scope(scope: CoroutineScope): MutableStoreBuilder<Key, Network, Output, Local> {
+        this.scope = scope
+        return this
+    }
+
+    override fun cachePolicy(memoryPolicy: MemoryPolicy<Key, Output>?): MutableStoreBuilder<Key, Network, Output, Local> {
+        cachePolicy = memoryPolicy
+        return this
+    }
+
+    override fun disableCache(): MutableStoreBuilder<Key, Network, Output, Local> {
+        cachePolicy = null
+        return this
+    }
+
+    override fun validator(validator: Validator<Output>): MutableStoreBuilder<Key, Network, Output, Local> {
+        this.validator = validator
+        return this
+    }
+
+    override fun converter(converter: Converter<Network, Output, Local>): MutableStoreBuilder<Key, Network, Output, Local> {
+        this.converter = converter
+        return this
+    }
+
+    fun build(): Store<Key, Output> = RealStore(
+        scope = scope ?: GlobalScope,
+        sourceOfTruth = sourceOfTruth,
+        fetcher = fetcher,
+        memoryPolicy = cachePolicy,
+        converter = converter,
+        validator = validator
+    )
+
+    override fun <UpdaterResult : Any> build(
+        updater: Updater<Key, Output, UpdaterResult>,
+        bookkeeper: Bookkeeper<Key>?
+    ): MutableStore<Key, Output> =
+        build().asMutableStore<Key, Network, Output, Local, UpdaterResult>(
+            updater = updater,
+            bookkeeper = bookkeeper
+        )
+}

--- a/store/src/commonMain/kotlin/org/mobilenativefoundation/store/store5/impl/RealMutableStoreBuilder.kt
+++ b/store/src/commonMain/kotlin/org/mobilenativefoundation/store/store5/impl/RealMutableStoreBuilder.kt
@@ -16,11 +16,15 @@ import org.mobilenativefoundation.store.store5.Validator
 import org.mobilenativefoundation.store.store5.impl.extensions.asMutableStore
 
 
-fun <Key : Any, Output : Any, Network : Any, Local : Any> mutableStoreBuilderFromFetcherAndSourceOfTruth(
+fun <Key : Any, Network : Any, Output : Any, Local : Any> mutableStoreBuilderFromFetcher(
+    fetcher: Fetcher<Key, Network>,
+): MutableStoreBuilder<Key, Network, Output, Local> = RealMutableStoreBuilder(fetcher)
+
+
+fun <Key : Any, Network : Any, Output : Any, Local : Any> mutableStoreBuilderFromFetcherAndSourceOfTruth(
     fetcher: Fetcher<Key, Network>,
     sourceOfTruth: SourceOfTruth<Key, Local>,
 ): MutableStoreBuilder<Key, Network, Output, Local> = RealMutableStoreBuilder(fetcher, sourceOfTruth)
-
 
 internal class RealMutableStoreBuilder<Key : Any, Network : Any, Output : Any, Local : Any>(
     private val fetcher: Fetcher<Key, Network>,

--- a/store/src/commonMain/kotlin/org/mobilenativefoundation/store/store5/impl/RealStoreBuilder.kt
+++ b/store/src/commonMain/kotlin/org/mobilenativefoundation/store/store5/impl/RealStoreBuilder.kt
@@ -14,7 +14,6 @@ import org.mobilenativefoundation.store.store5.StoreBuilder
 import org.mobilenativefoundation.store.store5.StoreDefaults
 import org.mobilenativefoundation.store.store5.Validator
 
-
 fun <Key : Any, Input : Any, Output : Any> storeBuilderFromFetcher(
     fetcher: Fetcher<Key, Input>,
     sourceOfTruth: SourceOfTruth<Key, *>? = null,
@@ -24,7 +23,6 @@ fun <Key : Any, Input : Any, Output : Any> storeBuilderFromFetcherAndSourceOfTru
     fetcher: Fetcher<Key, Input>,
     sourceOfTruth: SourceOfTruth<Key, *>,
 ): StoreBuilder<Key, Output> = RealStoreBuilder(fetcher, sourceOfTruth)
-
 
 internal class RealStoreBuilder<Key : Any, Network : Any, Output : Any, Local : Any>(
     private val fetcher: Fetcher<Key, Network>,

--- a/store/src/commonMain/kotlin/org/mobilenativefoundation/store/store5/impl/RealStoreBuilder.kt
+++ b/store/src/commonMain/kotlin/org/mobilenativefoundation/store/store5/impl/RealStoreBuilder.kt
@@ -65,36 +65,22 @@ internal class RealStoreBuilder<Key : Any, Network : Any, Output : Any, Local : 
     )
 
     override fun <Network : Any, Local : Any> toMutableStoreBuilder(): MutableStoreBuilder<Key, Network, Output, Local> {
-        val storeBuilder = this
         fetcher as Fetcher<Key, Network>
         return if (sourceOfTruth == null) {
-            mutableStoreBuilderFromFetcher<Key, Network, Output, Local>(fetcher).apply {
-                if (storeBuilder.scope != null) {
-                    scope(storeBuilder.scope!!)
-                }
-
-                if (storeBuilder.cachePolicy != null) {
-                    cachePolicy(storeBuilder.cachePolicy)
-                }
-
-                if (storeBuilder.validator != null) {
-                    validator(storeBuilder.validator!!)
-                }
-            }
+            mutableStoreBuilderFromFetcher(fetcher)
         } else {
-            sourceOfTruth as SourceOfTruth<Key, Local>
-            mutableStoreBuilderFromFetcherAndSourceOfTruth<Key, Network, Output, Local>(fetcher, sourceOfTruth).apply {
-                if (storeBuilder.scope != null) {
-                    scope(storeBuilder.scope!!)
-                }
+            mutableStoreBuilderFromFetcherAndSourceOfTruth<Key, Network, Output, Local>(fetcher, sourceOfTruth as SourceOfTruth<Key, Local>)
+        }.apply {
+            if (this@RealStoreBuilder.scope != null) {
+                scope(this@RealStoreBuilder.scope!!)
+            }
 
-                if (storeBuilder.cachePolicy != null) {
-                    cachePolicy(storeBuilder.cachePolicy)
-                }
+            if (this@RealStoreBuilder.cachePolicy != null) {
+                cachePolicy(this@RealStoreBuilder.cachePolicy)
+            }
 
-                if (storeBuilder.validator != null) {
-                    validator(storeBuilder.validator!!)
-                }
+            if (this@RealStoreBuilder.validator != null) {
+                validator(this@RealStoreBuilder.validator!!)
             }
         }
     }

--- a/store/src/commonMain/kotlin/org/mobilenativefoundation/store/store5/impl/RealStoreBuilder.kt
+++ b/store/src/commonMain/kotlin/org/mobilenativefoundation/store/store5/impl/RealStoreBuilder.kt
@@ -1,3 +1,5 @@
+@file:Suppress("UNCHECKED_CAST")
+
 package org.mobilenativefoundation.store.store5.impl
 
 import kotlinx.coroutines.CoroutineScope
@@ -5,6 +7,7 @@ import kotlinx.coroutines.GlobalScope
 import org.mobilenativefoundation.store.store5.Converter
 import org.mobilenativefoundation.store.store5.Fetcher
 import org.mobilenativefoundation.store.store5.MemoryPolicy
+import org.mobilenativefoundation.store.store5.MutableStoreBuilder
 import org.mobilenativefoundation.store.store5.SourceOfTruth
 import org.mobilenativefoundation.store.store5.Store
 import org.mobilenativefoundation.store.store5.StoreBuilder
@@ -60,4 +63,39 @@ internal class RealStoreBuilder<Key : Any, Network : Any, Output : Any, Local : 
         converter = converter,
         validator = validator
     )
+
+    override fun <Network : Any, Local : Any> toMutableStoreBuilder(): MutableStoreBuilder<Key, Network, Output, Local> {
+        val storeBuilder = this
+        fetcher as Fetcher<Key, Network>
+        return if (sourceOfTruth == null) {
+            mutableStoreBuilderFromFetcher<Key, Network, Output, Local>(fetcher).apply {
+                if (storeBuilder.scope != null) {
+                    scope(storeBuilder.scope!!)
+                }
+
+                if (storeBuilder.cachePolicy != null) {
+                    cachePolicy(storeBuilder.cachePolicy)
+                }
+
+                if (storeBuilder.validator != null) {
+                    validator(storeBuilder.validator!!)
+                }
+            }
+        } else {
+            sourceOfTruth as SourceOfTruth<Key, Local>
+            mutableStoreBuilderFromFetcherAndSourceOfTruth<Key, Network, Output, Local>(fetcher, sourceOfTruth).apply {
+                if (storeBuilder.scope != null) {
+                    scope(storeBuilder.scope!!)
+                }
+
+                if (storeBuilder.cachePolicy != null) {
+                    cachePolicy(storeBuilder.cachePolicy)
+                }
+
+                if (storeBuilder.validator != null) {
+                    validator(storeBuilder.validator!!)
+                }
+            }
+        }
+    }
 }

--- a/store/src/commonTest/kotlin/org/mobilenativefoundation/store/store5/ClearAllStoreTests.kt
+++ b/store/src/commonTest/kotlin/org/mobilenativefoundation/store/store5/ClearAllStoreTests.kt
@@ -43,7 +43,7 @@ class ClearAllStoreTests {
 
     @Test
     fun callingClearAllOnStoreWithPersisterAndNoInMemoryCacheDeletesAllEntriesFromThePersister() = testScope.runTest {
-        val store = StoreBuilder.from<String, Int, Int, Int>(
+        val store = StoreBuilder.from<String, Int, Int>(
             fetcher = fetcher,
             sourceOfTruth = persister.asSourceOfTruth()
         ).scope(testScope)

--- a/store/src/commonTest/kotlin/org/mobilenativefoundation/store/store5/ClearStoreByKeyTests.kt
+++ b/store/src/commonTest/kotlin/org/mobilenativefoundation/store/store5/ClearStoreByKeyTests.kt
@@ -24,7 +24,7 @@ class ClearStoreByKeyTests {
     fun callingClearWithKeyOnStoreWithPersisterWithNoInMemoryCacheDeletesTheEntryAssociatedWithTheKeyFromThePersister() = testScope.runTest {
         val key = "key"
         val value = 1
-        val store = StoreBuilder.from<String, Int, Int, Int>(
+        val store = StoreBuilder.from<String, Int, Int>(
             fetcher = Fetcher.of { value },
             sourceOfTruth = persister.asSourceOfTruth()
         ).scope(testScope)
@@ -107,7 +107,7 @@ class ClearStoreByKeyTests {
         val key2 = "key2"
         val value1 = 1
         val value2 = 2
-        val store = StoreBuilder.from<String, Int, Int, Int>(
+        val store = StoreBuilder.from<String, Int, Int>(
             fetcher = Fetcher.of { key ->
                 when (key) {
                     key1 -> value1

--- a/store/src/commonTest/kotlin/org/mobilenativefoundation/store/store5/FetcherResponseTests.kt
+++ b/store/src/commonTest/kotlin/org/mobilenativefoundation/store/store5/FetcherResponseTests.kt
@@ -211,6 +211,6 @@ class FetcherResponseTests {
         )
     }
 
-    private fun <Key : Any, Network : Any, Output : Any, Local : Any> StoreBuilder<Key, Network, Output, Local>.buildWithTestScope() =
+    private fun <Key : Any, Output : Any> StoreBuilder<Key, Output>.buildWithTestScope() =
         scope(testScope).build()
 }

--- a/store/src/commonTest/kotlin/org/mobilenativefoundation/store/store5/FlowStoreTests.kt
+++ b/store/src/commonTest/kotlin/org/mobilenativefoundation/store/store5/FlowStoreTests.kt
@@ -113,7 +113,7 @@ class FlowStoreTests {
             3 to "three-2"
         )
         val persister = InMemoryPersister<Int, String>()
-        val pipeline = StoreBuilder.from<Int, String, String, String>(
+        val pipeline = StoreBuilder.from<Int, String, String>(
             fetcher = fetcher,
             sourceOfTruth = persister.asSourceOfTruth()
         ).buildWithTestScope()
@@ -184,7 +184,7 @@ class FlowStoreTests {
         )
         val persister = InMemoryPersister<Int, String>()
 
-        val pipeline = StoreBuilder.from<Int, String, String, String>(
+        val pipeline = StoreBuilder.from<Int, String, String>(
             fetcher = fetcher,
             sourceOfTruth = persister.asSourceOfTruth()
         ).buildWithTestScope()
@@ -309,7 +309,7 @@ class FlowStoreTests {
         )
         val persister = InMemoryPersister<Int, String>()
 
-        val pipeline = StoreBuilder.from<Int, String, String, String>(
+        val pipeline = StoreBuilder.from<Int, String, String>(
             fetcher = fetcher,
             sourceOfTruth = persister.asSourceOfTruth()
         )
@@ -357,7 +357,7 @@ class FlowStoreTests {
     @Test
     fun diskChangeWhileNetworkIsFlowing_simple() = testScope.runTest {
         val persister = InMemoryPersister<Int, String>().asFlowable()
-        val pipeline = StoreBuilder.from<Int, String, String, String>(
+        val pipeline = StoreBuilder.from<Int, String, String>(
             Fetcher.ofFlow {
                 flow {
                     delay(20)
@@ -395,7 +395,7 @@ class FlowStoreTests {
     @Test
     fun diskChangeWhileNetworkIsFlowing_overwrite() = testScope.runTest {
         val persister = InMemoryPersister<Int, String>().asFlowable()
-        val pipeline = StoreBuilder.from<Int, String, String, String>(
+        val pipeline = StoreBuilder.from<Int, String, String>(
             fetcher = Fetcher.ofFlow {
                 flow {
                     delay(10)
@@ -445,7 +445,7 @@ class FlowStoreTests {
     fun errorTest() = testScope.runTest {
         val exception = IllegalArgumentException("wow")
         val persister = InMemoryPersister<Int, String>().asFlowable()
-        val pipeline = StoreBuilder.from<Int, String, String, String>(
+        val pipeline = StoreBuilder.from<Int, String, String>(
             Fetcher.of {
                 throw exception
             },
@@ -496,7 +496,7 @@ class FlowStoreTests {
     fun givenSourceOfTruthWhenStreamFreshDataReturnsNoDataFromFetcherThenFetchReturnsNoDataAndCachedValuesAreReceived() =
         testScope.runTest {
             val persister = InMemoryPersister<Int, String>().asFlowable()
-            val pipeline = StoreBuilder.from<Int, String, String, String>(
+            val pipeline = StoreBuilder.from<Int, String, String>(
                 fetcher = Fetcher.ofFlow { flow {} },
                 sourceOfTruth = persister.asSourceOfTruth()
             )
@@ -530,7 +530,7 @@ class FlowStoreTests {
     @Test
     fun givenSourceOfTruthWhenStreamCachedDataWithRefreshReturnsNoNewDataThenCachedValuesAreReceivedAndFetchReturnsNoData() = testScope.runTest {
         val persister = InMemoryPersister<Int, String>().asFlowable()
-        val pipeline = StoreBuilder.from<Int, String, String, String>(
+        val pipeline = StoreBuilder.from<Int, String, String>(
             fetcher = Fetcher.ofFlow { flow {} },
             sourceOfTruth = persister.asSourceOfTruth()
         )
@@ -687,7 +687,7 @@ class FlowStoreTests {
             3 to "three-2"
         )
         val persister = InMemoryPersister<Int, String>()
-        val pipeline = StoreBuilder.from<Int, String, String, String>(
+        val pipeline = StoreBuilder.from<Int, String, String>(
             fetcher = fetcher,
             sourceOfTruth = persister.asSourceOfTruth()
         ).buildWithTestScope()
@@ -865,6 +865,6 @@ class FlowStoreTests {
         )
     )
 
-    private fun <Key : Any, Network : Any, Output : Any, Local : Any> StoreBuilder<Key, Network, Output, Local>.buildWithTestScope() =
+    private fun <Key : Any, Output : Any> StoreBuilder<Key, Output>.buildWithTestScope() =
         scope(testScope).build()
 }

--- a/store/src/commonTest/kotlin/org/mobilenativefoundation/store/store5/SourceOfTruthErrorsTests.kt
+++ b/store/src/commonTest/kotlin/org/mobilenativefoundation/store/store5/SourceOfTruthErrorsTests.kt
@@ -31,7 +31,7 @@ class SourceOfTruthErrorsTests {
             3 to "b"
         )
         val pipeline = StoreBuilder
-            .from<Int, String, String, String>(
+            .from<Int, String, String>(
                 fetcher = fetcher,
                 sourceOfTruth = persister.asSourceOfTruth()
             )
@@ -65,7 +65,7 @@ class SourceOfTruthErrorsTests {
             3 to "b"
         )
         val pipeline = StoreBuilder
-            .from<Int, String, String, String>(
+            .from<Int, String, String>(
                 fetcher = fetcher,
                 sourceOfTruth = persister.asSourceOfTruth()
             )
@@ -110,7 +110,7 @@ class SourceOfTruthErrorsTests {
             flowOf("a", "b", "c", "d")
         }
         val pipeline = StoreBuilder
-            .from<Int, String, String, String>(
+            .from<Int, String, String>(
                 fetcher = fetcher,
                 sourceOfTruth = persister.asSourceOfTruth()
             )
@@ -240,7 +240,7 @@ class SourceOfTruthErrorsTests {
             }
         }
         val pipeline = StoreBuilder
-            .from<Int, String, String, String>(
+            .from<Int, String, String>(
                 fetcher = fetcher,
                 sourceOfTruth = persister.asSourceOfTruth()
             )
@@ -334,7 +334,7 @@ class SourceOfTruthErrorsTests {
             val persister = InMemoryPersister<Int, String>()
             val fetcher = Fetcher.of { _: Int -> "a" }
             val pipeline = StoreBuilder
-                .from<Int, String, String, String>(
+                .from<Int, String, String>(
                     fetcher = fetcher,
                     sourceOfTruth = persister.asSourceOfTruth()
                 )

--- a/store/src/commonTest/kotlin/org/mobilenativefoundation/store/store5/UpdaterTests.kt
+++ b/store/src/commonTest/kotlin/org/mobilenativefoundation/store/store5/UpdaterTests.kt
@@ -55,7 +55,7 @@ class UpdaterTests {
             clearAll = bookkeeping::clear
         )
 
-        val store = StoreBuilder.from<String, NetworkNote, CommonNote, SOTNote>(
+        val store = MutableStoreBuilder.from<String, NetworkNote, CommonNote, SOTNote>(
             fetcher = Fetcher.of { key -> api.get(key, ttl = ttl) },
             sourceOfTruth = SourceOfTruth.of(
                 nonFlowReader = { key -> notes.get(key) },
@@ -130,7 +130,7 @@ class UpdaterTests {
             clearAll = bookkeeping::clear
         )
 
-        val store = StoreBuilder.from<String, NetworkNote, CommonNote, SOTNote>(
+        val store = MutableStoreBuilder.from<String, NetworkNote, CommonNote, SOTNote>(
             fetcher = Fetcher.of { key -> api.get(key, ttl = ttl) },
             sourceOfTruth = SourceOfTruth.of(
                 nonFlowReader = { key -> notes.get(key) },
@@ -187,7 +187,7 @@ class UpdaterTests {
             clearAll = bookkeeping::clear
         )
 
-        val store = StoreBuilder.from<String, NetworkNote, CommonNote, SOTNote>(
+        val store = MutableStoreBuilder.from<String, NetworkNote, CommonNote, SOTNote>(
             fetcher = Fetcher.ofFlow { key ->
                 val network = api.get(key)
                 flow { emit(network) }


### PR DESCRIPTION
Store5's `StoreBuilder` caused a breaking change. See #532. We can avoid this breaking change by introducing a separate builder for `MutableStore`.