### PR TITLE
Support custom error types

### DIFF
--- a/store/src/commonMain/kotlin/org/mobilenativefoundation/store/store5/FetcherResult.kt
+++ b/store/src/commonMain/kotlin/org/mobilenativefoundation/store/store5/FetcherResult.kt
@@ -5,5 +5,6 @@ sealed class FetcherResult<out Network : Any> {
     sealed class Error : FetcherResult<Nothing>() {
         data class Exception(val error: Throwable) : Error()
         data class Message(val message: String) : Error()
+        data class Custom<E : Any>(val error: E) : Error()
     }
 }

--- a/store/src/commonMain/kotlin/org/mobilenativefoundation/store/store5/impl/FetcherController.kt
+++ b/store/src/commonMain/kotlin/org/mobilenativefoundation/store/store5/impl/FetcherController.kt
@@ -92,6 +92,10 @@ internal class FetcherController<Key : Any, Network : Any, Output : Any, Local :
                             it.error,
                             origin = StoreReadResponseOrigin.Fetcher()
                         )
+                        is FetcherResult.Error.Custom<*> -> StoreReadResponse.Error.Custom(
+                            it.error,
+                            StoreReadResponseOrigin.Fetcher()
+                        )
                     }
                 }.onEmpty {
                     val origin =


### PR DESCRIPTION
> Hello :spock-hand: ! Does someone have any guidance/sample project on how to handle network/http errors with Store? Currently the network layer in our Android app takes care of catching exceptions, parsing error payloads and returning a custom monad class like Result<NetworkError, T>> . Looking at StoreReadResponse it seems that using Throwable or String is the only way to go. Thanks for your answers!

https://kotlinlang.slack.com/archives/C06007Z01HU/p1699457424194509