### PR TITLE
Use only one generic error type

### DIFF
--- a/store/src/commonMain/kotlin/org/mobilenativefoundation/store/store5/Fetcher.kt
+++ b/store/src/commonMain/kotlin/org/mobilenativefoundation/store/store5/Fetcher.kt
@@ -103,7 +103,7 @@ interface Fetcher<Key : Any, Network : Any> {
         ): Fetcher<Key, Network> = FactoryFetcher { key: Key ->
             flowFactory(key)
                 .map<Network, FetcherResult<Network>> { FetcherResult.Data(it, name) }
-                .catch { throwable: Throwable -> emit(FetcherResult.Error.Exception(throwable)) }
+                .catch { throwable: Throwable -> emit(FetcherResult.Error(throwable)) }
         }
 
         /**
@@ -120,7 +120,7 @@ interface Fetcher<Key : Any, Network : Any> {
                 .map<Network, FetcherResult<Network>> {
                     FetcherResult.Data(it, name)
                 }
-                .catch { throwable: Throwable -> emit(FetcherResult.Error.Exception(throwable)) }
+                .catch { throwable: Throwable -> emit(FetcherResult.Error(throwable)) }
         }, fallback = fallback)
 
         /**
@@ -177,7 +177,7 @@ interface Fetcher<Key : Any, Network : Any> {
                         send(fetcherResult)
                     }
 
-                    is FetcherResult.Error -> {
+                    is FetcherResult.Error<*> -> {
                         if (fallback != null) {
                             tryFetch(key, fallback::invoke, fallback.fallback).collect { send(it) }
                         } else {

--- a/store/src/commonMain/kotlin/org/mobilenativefoundation/store/store5/FetcherResult.kt
+++ b/store/src/commonMain/kotlin/org/mobilenativefoundation/store/store5/FetcherResult.kt
@@ -5,5 +5,6 @@ sealed class FetcherResult<out Network : Any> {
     sealed class Error : FetcherResult<Nothing>() {
         data class Exception(val error: Throwable) : Error()
         data class Message(val message: String) : Error()
+        data class Custom<E: Throwable>(val error: E): Error()
     }
 }

--- a/store/src/commonMain/kotlin/org/mobilenativefoundation/store/store5/FetcherResult.kt
+++ b/store/src/commonMain/kotlin/org/mobilenativefoundation/store/store5/FetcherResult.kt
@@ -2,9 +2,5 @@ package org.mobilenativefoundation.store.store5
 
 sealed class FetcherResult<out Network : Any> {
     data class Data<Network : Any>(val value: Network, val origin: String? = null) : FetcherResult<Network>()
-    sealed class Error : FetcherResult<Nothing>() {
-        data class Exception(val error: Throwable) : Error()
-        data class Message(val message: String) : Error()
-        data class Custom<E : Any>(val error: E) : Error()
-    }
+    data class Error<E: Any>(val error: E) : FetcherResult<Nothing>()
 }

--- a/store/src/commonMain/kotlin/org/mobilenativefoundation/store/store5/FetcherResult.kt
+++ b/store/src/commonMain/kotlin/org/mobilenativefoundation/store/store5/FetcherResult.kt
@@ -5,6 +5,6 @@ sealed class FetcherResult<out Network : Any> {
     sealed class Error : FetcherResult<Nothing>() {
         data class Exception(val error: Throwable) : Error()
         data class Message(val message: String) : Error()
-        data class Custom<E: Throwable>(val error: E): Error()
+        data class Custom<E : Any>(val error: E) : Error()
     }
 }

--- a/store/src/commonMain/kotlin/org/mobilenativefoundation/store/store5/OnFetcherCompletion.kt
+++ b/store/src/commonMain/kotlin/org/mobilenativefoundation/store/store5/OnFetcherCompletion.kt
@@ -2,5 +2,5 @@ package org.mobilenativefoundation.store.store5
 
 data class OnFetcherCompletion<Network : Any>(
     val onSuccess: (FetcherResult.Data<Network>) -> Unit,
-    val onFailure: (FetcherResult.Error) -> Unit
+    val onFailure: (FetcherResult.Error<*>) -> Unit
 )

--- a/store/src/commonMain/kotlin/org/mobilenativefoundation/store/store5/OnUpdaterCompletion.kt
+++ b/store/src/commonMain/kotlin/org/mobilenativefoundation/store/store5/OnUpdaterCompletion.kt
@@ -2,5 +2,5 @@ package org.mobilenativefoundation.store.store5
 
 data class OnUpdaterCompletion<Response : Any>(
     val onSuccess: (UpdaterResult.Success) -> Unit,
-    val onFailure: (UpdaterResult.Error) -> Unit
+    val onFailure: (UpdaterResult.Error<*>) -> Unit
 )

--- a/store/src/commonMain/kotlin/org/mobilenativefoundation/store/store5/StoreReadResponse.kt
+++ b/store/src/commonMain/kotlin/org/mobilenativefoundation/store/store5/StoreReadResponse.kt
@@ -59,10 +59,10 @@ sealed class StoreReadResponse<out Output> {
             override val origin: StoreReadResponseOrigin
         ) : Error()
 
-        data class Custom<E: Throwable>(
+        data class Custom<E : Any>(
             val error: E,
             override val origin: StoreReadResponseOrigin
-        ): Error()
+        ) : Error()
     }
 
     /**
@@ -115,7 +115,7 @@ sealed class StoreReadResponse<out Output> {
     }
 
     @Suppress("UNCHECKED_CAST")
-    fun <E: Throwable> errorOrNull(): E? {
+    fun <E : Any> errorOrNull(): E? {
         if (this is Error.Custom<*>) {
             return (this as? Error.Custom<E>)?.error
         }
@@ -156,5 +156,11 @@ sealed class StoreReadResponseOrigin {
 fun StoreReadResponse.Error.doThrow(): Nothing = when (this) {
     is StoreReadResponse.Error.Exception -> throw error
     is StoreReadResponse.Error.Message -> throw RuntimeException(message)
-    is StoreReadResponse.Error.Custom<*> -> throw error
+    is StoreReadResponse.Error.Custom<*> -> {
+        if (error is Throwable) {
+            throw error
+        } else {
+            throw RuntimeException("Non-throwable custom error: $error")
+        }
+    }
 }

--- a/store/src/commonMain/kotlin/org/mobilenativefoundation/store/store5/StoreWriteResponse.kt
+++ b/store/src/commonMain/kotlin/org/mobilenativefoundation/store/store5/StoreWriteResponse.kt
@@ -6,8 +6,5 @@ sealed class StoreWriteResponse {
         data class Untyped(val value: Any) : Success()
     }
 
-    sealed class Error : StoreWriteResponse() {
-        data class Exception(val error: Throwable) : Error()
-        data class Message(val message: String) : Error()
-    }
+    data class Error<E: Any>(val error: E) : StoreWriteResponse()
 }

--- a/store/src/commonMain/kotlin/org/mobilenativefoundation/store/store5/UpdaterResult.kt
+++ b/store/src/commonMain/kotlin/org/mobilenativefoundation/store/store5/UpdaterResult.kt
@@ -7,8 +7,5 @@ sealed class UpdaterResult {
         data class Untyped(val value: Any) : Success()
     }
 
-    sealed class Error : UpdaterResult() {
-        data class Exception(val error: Throwable) : Error()
-        data class Message(val message: String) : Error()
-    }
+    data class Error<E: Any>(val error: E) : UpdaterResult()
 }

--- a/store/src/commonMain/kotlin/org/mobilenativefoundation/store/store5/impl/FetcherController.kt
+++ b/store/src/commonMain/kotlin/org/mobilenativefoundation/store/store5/impl/FetcherController.kt
@@ -83,19 +83,9 @@ internal class FetcherController<Key : Any, Network : Any, Output : Any, Local :
                             ) as StoreReadResponse<Network>
                         }
 
-                        is FetcherResult.Error.Message -> StoreReadResponse.Error.Message(
-                            it.message,
-                            origin = StoreReadResponseOrigin.Fetcher()
-                        )
-
-                        is FetcherResult.Error.Exception -> StoreReadResponse.Error.Exception(
+                        is FetcherResult.Error<*> -> StoreReadResponse.Error(
                             it.error,
                             origin = StoreReadResponseOrigin.Fetcher()
-                        )
-
-                        is FetcherResult.Error.Custom<*> -> StoreReadResponse.Error.Custom(
-                            it.error,
-                            StoreReadResponseOrigin.Fetcher()
                         )
                     }
                 }.onEmpty {

--- a/store/src/commonMain/kotlin/org/mobilenativefoundation/store/store5/impl/FetcherController.kt
+++ b/store/src/commonMain/kotlin/org/mobilenativefoundation/store/store5/impl/FetcherController.kt
@@ -93,7 +93,10 @@ internal class FetcherController<Key : Any, Network : Any, Output : Any, Local :
                             origin = StoreReadResponseOrigin.Fetcher()
                         )
 
-                        is FetcherResult.Error.Custom<*> -> StoreReadResponse.Error.Custom(it.error, StoreReadResponseOrigin.Fetcher())
+                        is FetcherResult.Error.Custom<*> -> StoreReadResponse.Error.Custom(
+                            it.error,
+                            StoreReadResponseOrigin.Fetcher()
+                        )
                     }
                 }.onEmpty {
                     val origin =

--- a/store/src/commonMain/kotlin/org/mobilenativefoundation/store/store5/impl/FetcherController.kt
+++ b/store/src/commonMain/kotlin/org/mobilenativefoundation/store/store5/impl/FetcherController.kt
@@ -92,6 +92,8 @@ internal class FetcherController<Key : Any, Network : Any, Output : Any, Local :
                             it.error,
                             origin = StoreReadResponseOrigin.Fetcher()
                         )
+
+                        is FetcherResult.Error.Custom<*> -> StoreReadResponse.Error.Custom(it.error, StoreReadResponseOrigin.Fetcher())
                     }
                 }.onEmpty {
                     val origin =

--- a/store/src/commonMain/kotlin/org/mobilenativefoundation/store/store5/impl/OnStoreWriteCompletion.kt
+++ b/store/src/commonMain/kotlin/org/mobilenativefoundation/store/store5/impl/OnStoreWriteCompletion.kt
@@ -4,5 +4,5 @@ import org.mobilenativefoundation.store.store5.StoreWriteResponse
 
 data class OnStoreWriteCompletion(
     val onSuccess: (StoreWriteResponse.Success) -> Unit,
-    val onFailure: (StoreWriteResponse.Error) -> Unit
+    val onFailure: (StoreWriteResponse.Error<*>) -> Unit
 )

--- a/store/src/commonMain/kotlin/org/mobilenativefoundation/store/store5/impl/RealStore.kt
+++ b/store/src/commonMain/kotlin/org/mobilenativefoundation/store/store5/impl/RealStore.kt
@@ -230,7 +230,7 @@ internal class RealStore<Key : Any, Network : Any, Output : Any, Local : Any>(
                     requestKeyToFetcherName[request.key] = responseOrigin.name
 
                     val fallBackToSourceOfTruth =
-                        it.value is StoreReadResponse.Error && request.fallBackToSourceOfTruth
+                        it.value is StoreReadResponse.Error<*> && request.fallBackToSourceOfTruth
 
                     if (it.value is StoreReadResponse.Data || it.value is StoreReadResponse.NoNewData || fallBackToSourceOfTruth) {
                         // Unlocking disk only if network sent data or reported no new data
@@ -278,7 +278,7 @@ internal class RealStore<Key : Any, Network : Any, Output : Any, Local : Any>(
                             }
                         }
 
-                        is StoreReadResponse.Error -> {
+                        is StoreReadResponse.Error<*> -> {
                             // disk sent an error, send it down as well
                             emit(diskData)
 
@@ -286,9 +286,7 @@ internal class RealStore<Key : Any, Network : Any, Output : Any, Local : Any>(
                             // values since there is nothing to read from disk. If disk sent a write
                             // error, we should NOT allow fetcher to start emitting values as we
                             // should always wait for the read attempt.
-                            if (diskData is StoreReadResponse.Error.Exception &&
-                                diskData.error is SourceOfTruth.ReadException
-                            ) {
+                            if (diskData.error is SourceOfTruth.ReadException) {
                                 networkLock.complete(Unit)
                             }
                             // for other errors, don't do anything, wait for the read attempt

--- a/store/src/commonMain/kotlin/org/mobilenativefoundation/store/store5/impl/RealStore.kt
+++ b/store/src/commonMain/kotlin/org/mobilenativefoundation/store/store5/impl/RealStore.kt
@@ -322,7 +322,7 @@ internal class RealStore<Key : Any, Network : Any, Output : Any, Local : Any>(
         sourceOfTruth?.write(key, converter.fromOutputToLocal(value))
         StoreDelegateWriteResult.Success
     } catch (error: Throwable) {
-        StoreDelegateWriteResult.Error.Exception(error)
+        StoreDelegateWriteResult.Error(error)
     }
 
     internal suspend fun latestOrNull(key: Key): Output? =

--- a/store/src/commonMain/kotlin/org/mobilenativefoundation/store/store5/impl/SourceOfTruthWithBarrier.kt
+++ b/store/src/commonMain/kotlin/org/mobilenativefoundation/store/store5/impl/SourceOfTruthWithBarrier.kt
@@ -101,7 +101,7 @@ internal class SourceOfTruthWithBarrier<Key : Any, Network : Any, Output : Any, 
                                         }
                                     }.catch { throwable ->
                                         this.emit(
-                                            StoreReadResponse.Error.Exception(
+                                            StoreReadResponse.Error(
                                                 error = SourceOfTruth.ReadException(
                                                     key = key,
                                                     cause = throwable.cause ?: throwable
@@ -120,7 +120,7 @@ internal class SourceOfTruthWithBarrier<Key : Any, Network : Any, Output : Any, 
                                     // if we have a pending error, make sure to dispatch it first.
                                     if (writeError != null) {
                                         emit(
-                                            StoreReadResponse.Error.Exception(
+                                            StoreReadResponse.Error(
                                                 origin = StoreReadResponseOrigin.SourceOfTruth,
                                                 error = writeError
                                             )

--- a/store/src/commonMain/kotlin/org/mobilenativefoundation/store/store5/internal/result/EagerConflictResolutionResult.kt
+++ b/store/src/commonMain/kotlin/org/mobilenativefoundation/store/store5/internal/result/EagerConflictResolutionResult.kt
@@ -9,8 +9,5 @@ sealed class EagerConflictResolutionResult<out Response : Any> {
         data class ConflictsResolved<Response : Any>(val value: UpdaterResult.Success) : Success<Response>()
     }
 
-    sealed class Error : EagerConflictResolutionResult<Nothing>() {
-        data class Message(val message: String) : Error()
-        data class Exception(val error: Throwable) : Error()
-    }
+    data class Error<E: Any>(val error: E) : EagerConflictResolutionResult<Nothing>()
 }

--- a/store/src/commonMain/kotlin/org/mobilenativefoundation/store/store5/internal/result/StoreDelegateWriteResult.kt
+++ b/store/src/commonMain/kotlin/org/mobilenativefoundation/store/store5/internal/result/StoreDelegateWriteResult.kt
@@ -2,8 +2,5 @@ package org.mobilenativefoundation.store.store5.internal.result
 
 sealed class StoreDelegateWriteResult {
     object Success : StoreDelegateWriteResult()
-    sealed class Error : StoreDelegateWriteResult() {
-        data class Message(val error: String) : Error()
-        data class Exception(val error: Throwable) : Error()
-    }
+    data class Error<E : Any>(val error: E) : StoreDelegateWriteResult()
 }

--- a/store/src/commonTest/kotlin/org/mobilenativefoundation/store/store5/FetcherResponseTests.kt
+++ b/store/src/commonTest/kotlin/org/mobilenativefoundation/store/store5/FetcherResponseTests.kt
@@ -38,7 +38,7 @@ class FetcherResponseTests {
             val store = StoreBuilder.from(
                 fetcher = Fetcher.ofResultFlow { key: Int ->
                     flowOf(
-                        FetcherResult.Error.Exception(exception),
+                        FetcherResult.Error(exception),
                         FetcherResult.Data("$key")
                     )
                 }
@@ -50,7 +50,7 @@ class FetcherResponseTests {
                 ),
                 listOf(
                     StoreReadResponse.Loading(StoreReadResponseOrigin.Fetcher()),
-                    StoreReadResponse.Error.Exception(exception, StoreReadResponseOrigin.Fetcher()),
+                    StoreReadResponse.Error(exception, StoreReadResponseOrigin.Fetcher()),
                     StoreReadResponse.Data("1", StoreReadResponseOrigin.Fetcher())
                 )
             )
@@ -94,7 +94,7 @@ class FetcherResponseTests {
                 if (it > 0) {
                     FetcherResult.Data(it)
                 } else {
-                    FetcherResult.Error.Message("zero")
+                    FetcherResult.Error("zero")
                 }
             }
         }
@@ -107,8 +107,8 @@ class FetcherResponseTests {
                 StoreReadResponse.Loading(
                     origin = StoreReadResponseOrigin.Fetcher()
                 ),
-                StoreReadResponse.Error.Message(
-                    message = "zero",
+                StoreReadResponse.Error(
+                    error = "zero",
                     origin = StoreReadResponseOrigin.Fetcher()
                 )
             )
@@ -136,7 +136,7 @@ class FetcherResponseTests {
                 if (it > 0) {
                     FetcherResult.Data(it)
                 } else {
-                    FetcherResult.Error.Exception(e)
+                    FetcherResult.Error(e)
                 }
             }
         }
@@ -150,7 +150,7 @@ class FetcherResponseTests {
                 StoreReadResponse.Loading(
                     origin = StoreReadResponseOrigin.Fetcher()
                 ),
-                StoreReadResponse.Error.Exception(
+                StoreReadResponse.Error(
                     error = e,
                     origin = StoreReadResponseOrigin.Fetcher()
                 )
@@ -191,7 +191,7 @@ class FetcherResponseTests {
                 StoreReadResponse.Loading(
                     origin = StoreReadResponseOrigin.Fetcher()
                 ),
-                StoreReadResponse.Error.Exception(
+                StoreReadResponse.Error(
                     error = e,
                     origin = StoreReadResponseOrigin.Fetcher()
                 )

--- a/store/src/commonTest/kotlin/org/mobilenativefoundation/store/store5/FlowStoreTests.kt
+++ b/store/src/commonTest/kotlin/org/mobilenativefoundation/store/store5/FlowStoreTests.kt
@@ -464,7 +464,7 @@ class FlowStoreTests {
                 Loading(
                     origin = StoreReadResponseOrigin.Fetcher()
                 ),
-                StoreReadResponse.Error.Exception(
+                StoreReadResponse.Error(
                     error = exception,
                     origin = StoreReadResponseOrigin.Fetcher()
                 ),
@@ -484,7 +484,7 @@ class FlowStoreTests {
                 Loading(
                     origin = StoreReadResponseOrigin.Fetcher()
                 ),
-                StoreReadResponse.Error.Exception(
+                StoreReadResponse.Error(
                     error = exception,
                     origin = StoreReadResponseOrigin.Fetcher()
                 )

--- a/store/src/commonTest/kotlin/org/mobilenativefoundation/store/store5/MutableStoreWithMultiCacheTests.kt
+++ b/store/src/commonTest/kotlin/org/mobilenativefoundation/store/store5/MutableStoreWithMultiCacheTests.kt
@@ -55,7 +55,7 @@ class MutableStoreWithMultiCacheTests {
             converter
         ).build(
             updater = Updater.by(
-                post = { _, _ -> UpdaterResult.Error.Exception(Exception()) }
+                post = { _, _ -> UpdaterResult.Error(Exception()) }
             )
         )
 

--- a/store/src/commonTest/kotlin/org/mobilenativefoundation/store/store5/SourceOfTruthErrorsTests.kt
+++ b/store/src/commonTest/kotlin/org/mobilenativefoundation/store/store5/SourceOfTruthErrorsTests.kt
@@ -45,7 +45,7 @@ class SourceOfTruthErrorsTests {
             pipeline.stream(StoreReadRequest.fresh(3)),
             listOf(
                 StoreReadResponse.Loading(StoreReadResponseOrigin.Fetcher()),
-                StoreReadResponse.Error.Exception(
+                StoreReadResponse.Error(
                     error = WriteException(
                         key = 3,
                         value = "a",
@@ -79,7 +79,7 @@ class SourceOfTruthErrorsTests {
         assertEmitsExactly(
             pipeline.stream(StoreReadRequest.cached(3, refresh = false)),
             listOf(
-                StoreReadResponse.Error.Exception(
+                StoreReadResponse.Error(
                     error = ReadException(
                         key = 3,
                         cause = TestException("null")
@@ -92,7 +92,7 @@ class SourceOfTruthErrorsTests {
                 ),
                 // and after fetcher writes the value, it will trigger another read which will also
                 // fail
-                StoreReadResponse.Error.Exception(
+                StoreReadResponse.Error(
                     error = ReadException(
                         key = 3,
                         cause = TestException("a")
@@ -129,7 +129,7 @@ class SourceOfTruthErrorsTests {
                 StoreReadResponse.Loading(
                     origin = StoreReadResponseOrigin.Fetcher()
                 ),
-                StoreReadResponse.Error.Exception(
+                StoreReadResponse.Error(
                     error = WriteException(
                         key = 3,
                         value = "a",
@@ -141,7 +141,7 @@ class SourceOfTruthErrorsTests {
                     value = "b",
                     origin = StoreReadResponseOrigin.Fetcher()
                 ),
-                StoreReadResponse.Error.Exception(
+                StoreReadResponse.Error(
                     error = WriteException(
                         key = 3,
                         value = "c",
@@ -350,7 +350,7 @@ class SourceOfTruthErrorsTests {
             assertEmitsExactly(
                 pipeline.stream(StoreReadRequest.cached(3, refresh = true)),
                 listOf(
-                    StoreReadResponse.Error.Exception(
+                    StoreReadResponse.Error(
                         origin = StoreReadResponseOrigin.SourceOfTruth,
                         error = ReadException(
                             key = 3,

--- a/store/src/commonTest/kotlin/org/mobilenativefoundation/store/store5/SourceOfTruthWithBarrierTests.kt
+++ b/store/src/commonTest/kotlin/org/mobilenativefoundation/store/store5/SourceOfTruthWithBarrierTests.kt
@@ -144,7 +144,7 @@ class SourceOfTruthWithBarrierTests {
         assertEmitsExactly(
             source.reader(1, CompletableDeferred(Unit)),
             listOf(
-                StoreReadResponse.Error.Exception(
+                StoreReadResponse.Error(
                     origin = StoreReadResponseOrigin.SourceOfTruth,
                     error = ReadException(
                         key = 1,
@@ -175,7 +175,7 @@ class SourceOfTruthWithBarrierTests {
         }
         advanceUntilIdle()
         assertEquals(
-            StoreReadResponse.Error.Exception(
+            StoreReadResponse.Error(
                 origin = StoreReadResponseOrigin.SourceOfTruth,
                 error = ReadException(
                     key = 1,
@@ -191,7 +191,7 @@ class SourceOfTruthWithBarrierTests {
         advanceUntilIdle()
         assertEquals(
             listOf<StoreReadResponse<String?>>(
-                StoreReadResponse.Error.Exception(
+                StoreReadResponse.Error(
                     origin = StoreReadResponseOrigin.SourceOfTruth,
                     error = ReadException(
                         key = 1,
@@ -237,7 +237,7 @@ class SourceOfTruthWithBarrierTests {
                     origin = StoreReadResponseOrigin.SourceOfTruth,
                     value = null
                 ),
-                StoreReadResponse.Error.Exception(
+                StoreReadResponse.Error(
                     origin = StoreReadResponseOrigin.SourceOfTruth,
                     error = WriteException(
                         key = 1,

--- a/store/src/commonTest/kotlin/org/mobilenativefoundation/store/store5/StoreReadResponseTests.kt
+++ b/store/src/commonTest/kotlin/org/mobilenativefoundation/store/store5/StoreReadResponseTests.kt
@@ -20,34 +20,47 @@ class StoreReadResponseTests {
     @Test
     fun throwIfErrorException() {
         assertFailsWith<Exception> {
-            StoreReadResponse.Error.Exception(Exception(), StoreReadResponseOrigin.Fetcher()).throwIfError()
+            StoreReadResponse.Error(Exception(), StoreReadResponseOrigin.Fetcher()).throwIfError()
         }
     }
 
     @Test
     fun throwIfErrorMessage() {
         assertFailsWith<RuntimeException> {
-            StoreReadResponse.Error.Message("test error", StoreReadResponseOrigin.Fetcher()).throwIfError()
+            StoreReadResponse.Error("test error", StoreReadResponseOrigin.Fetcher()).throwIfError()
         }
     }
 
     @Test()
     fun errorMessageOrNull() {
         assertFailsWith<Exception>(message = Exception::class.toString()) {
-            StoreReadResponse.Error.Exception(Exception(), StoreReadResponseOrigin.Fetcher()).throwIfError()
+            StoreReadResponse.Error(Exception(), StoreReadResponseOrigin.Fetcher()).throwIfError()
         }
 
         assertFailsWith<Exception>(message = "test error message") {
-            StoreReadResponse.Error.Message("test error message", StoreReadResponseOrigin.Fetcher()).throwIfError()
+            StoreReadResponse.Error("test error message", StoreReadResponseOrigin.Fetcher()).throwIfError()
         }
 
         assertNull(StoreReadResponse.Loading(StoreReadResponseOrigin.Fetcher()).errorMessageOrNull())
     }
+
 
     @Test
     fun swapType() {
         assertFailsWith<RuntimeException> {
             StoreReadResponse.Data("Foo", StoreReadResponseOrigin.Fetcher()).swapType<String>()
         }
+    }
+
+    enum class Error { NetworkUnavailable, ServerError }
+
+    @Test()
+    fun errorOrNull() {
+        val error = StoreReadResponse.Error(
+                error = Error.NetworkUnavailable,
+                origin = StoreReadResponseOrigin.Fetcher()
+            )
+
+        assertEquals(Error.NetworkUnavailable, error.error)
     }
 }

--- a/store/src/commonTest/kotlin/org/mobilenativefoundation/store/store5/ValueFetcherTests.kt
+++ b/store/src/commonTest/kotlin/org/mobilenativefoundation/store/store5/ValueFetcherTests.kt
@@ -31,7 +31,7 @@ class ValueFetcherTests {
         }
         assertEmitsExactly(
             fetcher(3),
-            listOf(FetcherResult.Error.Exception(e))
+            listOf(FetcherResult.Error(e))
         )
     }
 
@@ -51,6 +51,6 @@ class ValueFetcherTests {
         val fetcher = Fetcher.of<Int, Int> {
             throw e
         }
-        assertEmitsExactly(fetcher(3), listOf(FetcherResult.Error.Exception(e)))
+        assertEmitsExactly(fetcher(3), listOf(FetcherResult.Error(e)))
     }
 }

--- a/store/src/commonTest/kotlin/org/mobilenativefoundation/store/store5/util/fake/NotesUpdaterProvider.kt
+++ b/store/src/commonTest/kotlin/org/mobilenativefoundation/store/store5/util/fake/NotesUpdaterProvider.kt
@@ -13,7 +13,7 @@ internal class NotesUpdaterProvider(private val api: NotesApi) {
             if (response.ok) {
                 UpdaterResult.Success.Typed(response)
             } else {
-                UpdaterResult.Error.Message("Failed to sync")
+                UpdaterResult.Error("Failed to sync")
             }
         }
     )


### PR DESCRIPTION
## Description

Following [this discussion](https://github.com/MobileNativeFoundation/Store/pull/583), I wanted to experiment with a single generic `Error` type that could fit all use cases.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Test Plan
How has this been tested? Please describe the tests that you added to verify your changes.

## Checklist:
Before submitting your PR, please review and check all of the following:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my change is effective
- [x] New and existing unit tests pass locally with my changes

## Additional Notes:
Add any other information about the PR here.
