### PR TITLE
Add Cache.getAllPresent()

### DIFF
--- a/cache/src/commonMain/kotlin/org/mobilenativefoundation/store/cache5/Cache.kt
+++ b/cache/src/commonMain/kotlin/org/mobilenativefoundation/store/cache5/Cache.kt
@@ -18,6 +18,7 @@ interface Cache<Key : Any, Value : Any> {
 
     /**
      * @return Map of the [Value] associated with each [Key] in [keys]. Returned map only contains entries already present in the cache.
+     * The default implementation provided here throws a [NotImplementedError] to maintain backward compatibility for existing implementations.
      */
     fun getAllPresent(keys: List<*>): Map<Key, Value>
 

--- a/cache/src/commonMain/kotlin/org/mobilenativefoundation/store/cache5/Cache.kt
+++ b/cache/src/commonMain/kotlin/org/mobilenativefoundation/store/cache5/Cache.kt
@@ -22,6 +22,11 @@ interface Cache<Key : Any, Value : Any> {
     fun getAllPresent(keys: List<*>): Map<Key, Value>
 
     /**
+     * @return Map of the [Value] associated with each [Key] in the cache.
+     */
+    fun getAllPresent(): Map<Key, Value> = throw NotImplementedError()
+
+    /**
      * Associates [value] with [key].
      * If the cache previously contained a value associated with [key], the old value is replaced by [value].
      * Prefer [getOrPut] when using the conventional "If cached, then return. Otherwise create, cache, and then return" pattern.

--- a/cache/src/commonMain/kotlin/org/mobilenativefoundation/store/cache5/LocalCache.kt
+++ b/cache/src/commonMain/kotlin/org/mobilenativefoundation/store/cache5/LocalCache.kt
@@ -1384,18 +1384,18 @@ internal class LocalCache<K : Any, V : Any>(builder: CacheBuilder<K, V>) {
             if (count.value == 0) return emptyMap()
             reentrantLock.lock()
             return try {
-                buildMap {
-                    val table = table.value
-                    for (i in 0 until table.size) {
-                        var e = table[i]
-                        while (e != null) {
-                            if (e.valueReference!!.isActive) {
-                                put(e.key, e.valueReference!!.get()!!)
-                            }
-                            e = e.next
+                val activeMap = mutableMapOf<K, V>()
+                val table = table.value
+                for (i in 0 until table.size) {
+                    var e = table[i]
+                    while (e != null) {
+                        if (e.valueReference?.isActive == true) {
+                            activeMap[e.key] = e.valueReference?.get()!!
                         }
+                        e = e.next
                     }
                 }
+                activeMap.ifEmpty { emptyMap() }
             } finally {
                 reentrantLock.unlock()
             }

--- a/cache/src/commonMain/kotlin/org/mobilenativefoundation/store/cache5/StoreMultiCache.kt
+++ b/cache/src/commonMain/kotlin/org/mobilenativefoundation/store/cache5/StoreMultiCache.kt
@@ -88,6 +88,16 @@ class StoreMultiCache<Id : Any, Key : StoreKey<Id>, Single : StoreData.Single<Id
         return map
     }
 
+    override fun getAllPresent(): Map<Key, Output> {
+        return accessor.getAllPresent().mapKeys { (key, _) ->
+            when (key) {
+                is StoreKey.Collection<Id> -> key.cast()
+                is StoreKey.Single<Id> -> key.cast()
+                else -> throw UnsupportedOperationException(invalidKeyErrorMessage(key))
+            }
+        } as Map<Key, Output>
+    }
+
     override fun invalidateAll(keys: List<Key>) {
         keys.forEach { key -> invalidate(key) }
     }

--- a/cache/src/commonMain/kotlin/org/mobilenativefoundation/store/cache5/StoreMultiCacheAccessor.kt
+++ b/cache/src/commonMain/kotlin/org/mobilenativefoundation/store/cache5/StoreMultiCacheAccessor.kt
@@ -51,6 +51,33 @@ class StoreMultiCacheAccessor<Id : Any, Collection : StoreData.Collection<Id, Si
     }
 
     /**
+     * Retrieves all items from the cache.
+     *
+     * This operation is thread-safe.
+     */
+    fun getAllPresent(): Map<StoreKey<Id>, Any> = synchronized(this) {
+        val result = mutableMapOf<StoreKey<Id>, Any>()
+        for (key in keys) {
+            when (key) {
+                is StoreKey.Single<Id> -> {
+                    val single = singlesCache.getIfPresent(key)
+                    if (single != null) {
+                        result[key] = single
+                    }
+                }
+
+                is StoreKey.Collection<Id> -> {
+                    val collection = collectionsCache.getIfPresent(key)
+                    if (collection != null) {
+                        result[key] = collection
+                    }
+                }
+            }
+        }
+        result
+    }
+
+    /**
      * Stores a collection of items in the cache and updates the key set.
      *
      * This operation is thread-safe.

--- a/cache/src/commonTest/kotlin/org/mobilenativefoundation/store/cache5/CacheTests.kt
+++ b/cache/src/commonTest/kotlin/org/mobilenativefoundation/store/cache5/CacheTests.kt
@@ -20,12 +20,12 @@ class CacheTests {
     assertEquals("value", cache.getOrPut("key") { "value" })
   }
 
-  @Ignore // Not implemented yet
   @Test
   fun getAllPresent() {
     cache.put("key1", "value1")
     cache.put("key2", "value2")
     assertEquals(mapOf("key1" to "value1", "key2" to "value2"), cache.getAllPresent(listOf("key1", "key2")))
+    assertEquals(mapOf("key1" to "value1", "key2" to "value2"), cache.getAllPresent())
   }
 
   @Ignore // Not implemented yet


### PR DESCRIPTION
## Description
Adds `getAllPresent()` with no argument to `Cache`, in addition to existing `getAllPresent(keys: List<*>)`.
In the original Guava library there was an [`asMap()`](https://github.com/google/guava/blob/master/guava/src/com/google/common/cache/Cache.java#L178) method which could be used to get the contents of the cache.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Test Plan
Removed `@Ignore` from the `getAllPresent()` test.

## Checklist:
Before submitting your PR, please review and check all of the following:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (N/A)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my change is effective
- [x] New and existing unit tests pass locally with my changes

## Additional Notes:
Used `clear()` as an inspiration for the implementation.
