### PR TITLE
Update ChannelManager.kt

### DIFF
--- a/multicast/build.gradle.kts
+++ b/multicast/build.gradle.kts
@@ -47,6 +47,15 @@ kotlin {
                 implementation(libs.kotlinx.coroutines.core)
             }
         }
+
+        val commonTest by getting {
+            dependencies {
+                implementation(kotlin("test"))
+                implementation(libs.junit)
+                implementation(libs.kotlinx.coroutines.test)
+            }
+        }
+
         val jvmMain by getting
         val androidMain by getting
         val nativeMain by creating {

--- a/multicast/build.gradle.kts
+++ b/multicast/build.gradle.kts
@@ -53,6 +53,7 @@ kotlin {
                 implementation(kotlin("test"))
                 implementation(libs.junit)
                 implementation(libs.kotlinx.coroutines.test)
+                implementation(libs.turbine)
             }
         }
 

--- a/multicast/src/commonMain/kotlin/org/mobilenativefoundation/store/multicast5/ChannelManager.kt
+++ b/multicast/src/commonMain/kotlin/org/mobilenativefoundation/store/multicast5/ChannelManager.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.SendChannel
 import kotlinx.coroutines.flow.Flow
 import org.mobilenativefoundation.store.multicast5.ChannelManager.Message
+import kotlin.coroutines.cancellation.CancellationException
 
 internal interface ChannelManager<T> {
 
@@ -55,7 +56,11 @@ internal interface ChannelManager<T> {
 
         suspend fun dispatchValue(value: Message.Dispatch.Value<T>) {
             _awaitsDispatch = false
-            channel.send(value)
+            try {
+                channel.send(value)
+            } catch (e: CancellationException) {
+                // ignore
+            }
         }
 
         fun dispatchError(error: Throwable) {

--- a/multicast/src/commonTest/kotlin/org/mobilenativefoundation/store/multicast5/StoreChannelManagerTests.kt
+++ b/multicast/src/commonTest/kotlin/org/mobilenativefoundation/store/multicast5/StoreChannelManagerTests.kt
@@ -1,0 +1,73 @@
+package org.mobilenativefoundation.store.multicast5
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.consumeAsFlow
+import kotlinx.coroutines.flow.filterIsInstance
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class StoreChannelManagerTests {
+
+    @Test
+    fun cancelledDownstreamChannelShouldNotCancelOtherChannels() {
+        val messages = listOf(1, 2, 3)
+        val scope = CoroutineScope(Dispatchers.Default)
+        val lockUpstream = Mutex(true)
+        val upstreamFlow = flow {
+            lockUpstream.withLock {
+                messages.onEach { emit(it) }
+            }
+        }
+        val channelManager = StoreChannelManager(
+            scope = scope,
+            bufferSize = 0,
+            upstream = upstreamFlow,
+            piggybackingDownstream = false,
+            keepUpstreamAlive = false,
+            onEach = { }
+        )
+        val channels =
+            (1..20).map { Channel<ChannelManager.Message.Dispatch<Int>>(Channel.UNLIMITED) }
+
+        val cancelledChannel =
+            Channel<ChannelManager.Message.Dispatch<Int>>(Channel.UNLIMITED).also {
+                scope.launch {
+                    it.consumeAsFlow().first()
+                }
+            }
+
+        scope.launch {
+            channels.forEach { channelManager.addDownstream(it) }
+            lockUpstream.unlock()
+        }
+        scope.launch { channelManager.addDownstream(cancelledChannel) }
+
+        runTest {
+            channels.forEach { channel ->
+                val messagesFlow = channel.consumeAsFlow()
+                    .filterIsInstance<ChannelManager.Message.Dispatch.Value<Int>>()
+                    .onEach { it.delivered.complete(Unit) }
+                    .map { it.value }
+
+                assertEquals(
+                    messages,
+                    messagesFlow.take(3).toList(),
+                )
+            }
+        }
+        scope.cancel()
+    }
+}


### PR DESCRIPTION
Closes #636 

## Description
The cancellation exception on upstream channel does not cause the closure of all other channels.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Test Plan
How has this been tested? Please describe the tests that you added to verify your changes.

## Checklist:
Before submitting your PR, please review and check all of the following:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my change is effective
- [x] New and existing unit tests pass locally with my changes

## Additional Notes:
The cancellation exception from the upstream channel was caught in the StoreActor while handling messages. This caused the closure of the actor.