### PR TITLE
Target WasmJS

### DIFF
--- a/cache/build.gradle.kts
+++ b/cache/build.gradle.kts
@@ -1,15 +1,8 @@
-import org.jetbrains.kotlin.gradle.targets.js.dsl.ExperimentalWasmDsl
-
 plugins {
     id("org.mobilenativefoundation.store.multiplatform")
 }
 
 kotlin {
-
-    @OptIn(ExperimentalWasmDsl::class)
-    wasmJs {
-        nodejs()
-    }
 
     sourceSets {
         val commonMain by getting {

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -1,15 +1,8 @@
-import org.jetbrains.kotlin.gradle.targets.js.dsl.ExperimentalWasmDsl
-
 plugins {
     id("org.mobilenativefoundation.store.multiplatform")
 }
 
 kotlin {
-
-    @OptIn(ExperimentalWasmDsl::class)
-    wasmJs {
-        nodejs()
-    }
 
     sourceSets {
         val commonMain by getting {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -47,7 +47,7 @@ kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-
 kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "kotlinxCoroutines" }
 kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "kotlinxCoroutines" }
 kotlinx-coroutines-rx2 = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-rx2", version.ref = "kotlinxCoroutines" }
-kotlinx-datetime = { group = "org.jetbrains.kotlinx", name = "kotlinx-datetime", version = "0.4.0" }
+kotlinx-datetime = { group = "org.jetbrains.kotlinx", name = "kotlinx-datetime", version = "0.6.1" }
 molecule-gradle-plugin = { module = "app.cash.molecule:molecule-gradle-plugin", version.ref = "moleculeGradlePlugin" }
 molecule-runtime = { module = "app.cash.molecule:molecule-runtime", version.ref = "moleculeGradlePlugin" }
 rxjava = { group = "io.reactivex.rxjava2", name = "rxjava", version = "2.2.21" }
@@ -56,7 +56,7 @@ kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-cor
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 google-truth = { group = "com.google.truth", name = "truth", version.ref = "truth" }
 touchlab-kermit = { group = "co.touchlab", name = "kermit", version.ref = "kermit" }
-turbine = "app.cash.turbine:turbine:1.0.0"
+turbine = "app.cash.turbine:turbine:1.2.0"
 binary-compatibility-validator = {module = "org.jetbrains.kotlinx:binary-compatibility-validator", version.ref = "binary-compatibility-validator"}
 
 [plugins]

--- a/store/api/android/store.api
+++ b/store/api/android/store.api
@@ -378,7 +378,7 @@ public final class org/mobilenativefoundation/store/store5/StoreReadResponse$NoN
 }
 
 public final class org/mobilenativefoundation/store/store5/StoreReadResponseKt {
-	public static final fun doThrow (Lorg/mobilenativefoundation/store/store5/StoreReadResponse$Error;)Ljava/lang/Void;
+	public static final fun doThrow (Lorg/mobilenativefoundation/store/store5/StoreReadResponse$Error;)Ljava/lang/Throwable;
 }
 
 public abstract class org/mobilenativefoundation/store/store5/StoreReadResponseOrigin {

--- a/store/api/jvm/store.api
+++ b/store/api/jvm/store.api
@@ -371,7 +371,7 @@ public final class org/mobilenativefoundation/store/store5/StoreReadResponse$NoN
 }
 
 public final class org/mobilenativefoundation/store/store5/StoreReadResponseKt {
-	public static final fun doThrow (Lorg/mobilenativefoundation/store/store5/StoreReadResponse$Error;)Ljava/lang/Void;
+	public static final fun doThrow (Lorg/mobilenativefoundation/store/store5/StoreReadResponse$Error;)Ljava/lang/Throwable;
 }
 
 public abstract class org/mobilenativefoundation/store/store5/StoreReadResponseOrigin {

--- a/store/src/commonMain/kotlin/org/mobilenativefoundation/store/store5/StoreReadResponse.kt
+++ b/store/src/commonMain/kotlin/org/mobilenativefoundation/store/store5/StoreReadResponse.kt
@@ -75,7 +75,7 @@ sealed class StoreReadResponse<out Output> {
     fun requireData(): Output {
         return when (this) {
             is Data -> value
-            is Error -> this.doThrow()
+            is Error -> throw this.doThrow()
             else -> throw NullPointerException("there is no data in $this")
         }
     }
@@ -86,7 +86,7 @@ sealed class StoreReadResponse<out Output> {
      */
     fun throwIfError() {
         if (this is Error) {
-            this.doThrow()
+            throw this.doThrow()
         }
     }
 
@@ -165,15 +165,16 @@ sealed class StoreReadResponseOrigin {
     object Initial : StoreReadResponseOrigin()
 }
 
-fun StoreReadResponse.Error.doThrow(): Nothing =
-    when (this) {
-        is StoreReadResponse.Error.Exception -> throw error
-        is StoreReadResponse.Error.Message -> throw RuntimeException(message)
+fun StoreReadResponse.Error.doThrow(): Throwable {
+    return when (this) {
+        is StoreReadResponse.Error.Exception -> error
+        is StoreReadResponse.Error.Message -> RuntimeException(message)
         is StoreReadResponse.Error.Custom<*> -> {
             if (error is Throwable) {
-                throw error
+                error
             } else {
-                throw RuntimeException("Non-throwable custom error: $error")
+                RuntimeException("Non-throwable custom error: $error")
             }
         }
     }
+}

--- a/tooling/plugins/src/main/kotlin/org/mobilenativefoundation/store/tooling/plugins/KotlinMultiplatformConventionPlugin.kt
+++ b/tooling/plugins/src/main/kotlin/org/mobilenativefoundation/store/tooling/plugins/KotlinMultiplatformConventionPlugin.kt
@@ -17,6 +17,7 @@ import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.get
 import org.gradle.kotlin.dsl.withType
 import org.jetbrains.dokka.gradle.DokkaTask
+import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 
@@ -54,6 +55,11 @@ class KotlinMultiplatformConventionPlugin : Plugin<Project> {
 
             js {
                 browser()
+                nodejs()
+            }
+
+            @OptIn(ExperimentalWasmDsl::class)
+            wasmJs {
                 nodejs()
             }
 


### PR DESCRIPTION
Closes #644 

## Test Plan
All existing unit tests are passing

## Additional Notes:
https://youtrack.jetbrains.com/issue/KT-69534/WasmJs-compilation-fails-with-anonymous-objects-and-exception-throwing-in-when-expressions. Changes to compile:
- Replaced anonymous object with private class `DefaultConverter` (see `RealStoreBuilder.kt`) 
- Refactored `StoreReadResponse.Error.doThrow()` to return `Throwable` (see `StoreReadResponse.kt`)

Updated:
- https://github.com/Kotlin/kotlinx.serialization
- https://github.com/cashapp/turbine
- https://github.com/touchlab/Kermit
- https://github.com/Kotlin/kotlinx-datetime