### PR TITLE
Update kotlinx-datetime to 0.7.0 compatibility version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,11 +26,11 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
-          java-version: '11'
+          java-version: '17'
 
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
@@ -59,11 +59,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
-          java-version: '11'
+          java-version: '17'
 
       - name: Grant execute permission for Gradlew
         run: chmod +x gradlew

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -49,13 +49,13 @@ subprojects {
 tasks {
     withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
         kotlinOptions {
-            jvmTarget = "11"
+            jvmTarget = "17"
         }
     }
 
     withType<JavaCompile>().configureEach {
-        sourceCompatibility = JavaVersion.VERSION_11.name
-        targetCompatibility = JavaVersion.VERSION_11.name
+        sourceCompatibility = JavaVersion.VERSION_17.name
+        targetCompatibility = JavaVersion.VERSION_17.name
     }
 }
 

--- a/cache/api/android/cache.api
+++ b/cache/api/android/cache.api
@@ -1,10 +1,3 @@
-public final class org/mobilenativefoundation/store/cache/BuildConfig {
-	public static final field BUILD_TYPE Ljava/lang/String;
-	public static final field DEBUG Z
-	public static final field LIBRARY_PACKAGE_NAME Ljava/lang/String;
-	public fun <init> ()V
-}
-
 public abstract interface class org/mobilenativefoundation/store/cache5/Cache {
 	public abstract fun getAllPresent ()Ljava/util/Map;
 	public abstract fun getAllPresent (Ljava/util/List;)Ljava/util/Map;

--- a/core/api/android/core.api
+++ b/core/api/android/core.api
@@ -1,10 +1,3 @@
-public final class org/mobilenativefoundation/store/core/BuildConfig {
-	public static final field BUILD_TYPE Ljava/lang/String;
-	public static final field DEBUG Z
-	public static final field LIBRARY_PACKAGE_NAME Ljava/lang/String;
-	public fun <init> ()V
-}
-
 public abstract interface annotation class org/mobilenativefoundation/store/core5/ExperimentalStoreApi : java/lang/annotation/Annotation {
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -26,3 +26,6 @@ kotlinx.atomicfu.enableJsIrTransformation=false
 kotlin.js.compiler=ir
 
 org.jetbrains.compose.experimental.uikit.enabled=true
+
+# Suppress warning about AGP 8.11.0 being higher than tested version
+kotlin.mpp.androidGradlePluginCompatibility.nowarn=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -48,7 +48,7 @@ kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-
 kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "kotlinxCoroutines" }
 kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "kotlinxCoroutines" }
 kotlinx-coroutines-rx2 = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-rx2", version.ref = "kotlinxCoroutines" }
-kotlinx-datetime = { group = "org.jetbrains.kotlinx", name = "kotlinx-datetime", version = "0.6.2" }
+kotlinx-datetime = { group = "org.jetbrains.kotlinx", name = "kotlinx-datetime", version = "0.7.0-0.6.x-compat" }
 molecule-gradle-plugin = { module = "app.cash.molecule:molecule-gradle-plugin", version.ref = "moleculeGradlePlugin" }
 molecule-runtime = { module = "app.cash.molecule:molecule-runtime", version.ref = "moleculeGradlePlugin" }
 rxjava = { group = "io.reactivex.rxjava2", name = "rxjava", version = "2.2.21" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 androidMinSdk = "24"
-androidCompileSdk = "33"
-androidGradlePlugin = "7.4.2"
+androidCompileSdk = "35"
+androidGradlePlugin = "8.11.0"
 androidTargetSdk = "33"
 atomicFu = "0.24.0"
 baseKotlin = "2.0.20"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/multicast/api/android/multicast.api
+++ b/multicast/api/android/multicast.api
@@ -1,10 +1,3 @@
-public final class org/mobilenativefoundation/store/multicast/BuildConfig {
-	public static final field BUILD_TYPE Ljava/lang/String;
-	public static final field DEBUG Z
-	public static final field LIBRARY_PACKAGE_NAME Ljava/lang/String;
-	public fun <init> ()V
-}
-
 public final class org/mobilenativefoundation/store/multicast5/Multicaster {
 	public fun <init> (Lkotlinx/coroutines/CoroutineScope;ILkotlinx/coroutines/flow/Flow;ZZLkotlin/jvm/functions/Function2;)V
 	public synthetic fun <init> (Lkotlinx/coroutines/CoroutineScope;ILkotlinx/coroutines/flow/Flow;ZZLkotlin/jvm/functions/Function2;ILkotlin/jvm/internal/DefaultConstructorMarker;)V

--- a/store/api/android/store.api
+++ b/store/api/android/store.api
@@ -14,13 +14,6 @@ public final class org/mobilenativefoundation/store/store5/Bookkeeper$DefaultImp
 	public static synthetic fun setLastFailedSync$default (Lorg/mobilenativefoundation/store/store5/Bookkeeper;Ljava/lang/Object;JLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
-public final class org/mobilenativefoundation/store/store5/BuildConfig {
-	public static final field BUILD_TYPE Ljava/lang/String;
-	public static final field DEBUG Z
-	public static final field LIBRARY_PACKAGE_NAME Ljava/lang/String;
-	public fun <init> ()V
-}
-
 public abstract interface class org/mobilenativefoundation/store/store5/Clear {
 }
 

--- a/tooling/plugins/src/main/kotlin/org/mobilenativefoundation/store/tooling/plugins/KotlinMultiplatformConventionPlugin.kt
+++ b/tooling/plugins/src/main/kotlin/org/mobilenativefoundation/store/tooling/plugins/KotlinMultiplatformConventionPlugin.kt
@@ -63,7 +63,7 @@ class KotlinMultiplatformConventionPlugin : Plugin<Project> {
                 nodejs()
             }
 
-            jvmToolchain(11)
+            jvmToolchain(17)
 
             targets.all {
                 compilations.all {
@@ -137,7 +137,7 @@ fun Project.configureKotlin() {
 fun Project.configureJava() {
     java {
         toolchain {
-            languageVersion.set(JavaLanguageVersion.of(11))
+            languageVersion.set(JavaLanguageVersion.of(17))
         }
     }
 }
@@ -158,8 +158,8 @@ fun Project.configureAndroid() {
         }
 
         compileOptions {
-            sourceCompatibility = JavaVersion.VERSION_11
-            targetCompatibility = JavaVersion.VERSION_11
+            sourceCompatibility = JavaVersion.VERSION_17
+            targetCompatibility = JavaVersion.VERSION_17
         }
     }
 }
@@ -171,7 +171,7 @@ private fun Project.java(action: JavaPluginExtension.() -> Unit) = extensions.co
 
 
 object Versions {
-    const val COMPILE_SDK = 34
+    const val COMPILE_SDK = 35
     const val MIN_SDK = 24
     const val TARGET_SDK = 34
     const val STORE = "5.1.0-alpha06"


### PR DESCRIPTION
Updates kotlinx-datetime from 0.6.2 to 0.7.0-0.6.x-compat to resolve breaking changes introduced in 0.7.0 where Clock and Instant were moved from kotlinx.datetime to kotlin.time.

This compatibility version maintains the existing API while supporting kotlinx-datetime 0.7.0, avoiding the need to migrate to Kotlin 2.1+ immediately.

Fixes #703