### PR TITLE
fix: stop Store from reconfiguring the host app's global Kermit logger

### DIFF
--- a/store/src/commonMain/kotlin/org/mobilenativefoundation/store/store5/impl/DefaultLogger.kt
+++ b/store/src/commonMain/kotlin/org/mobilenativefoundation/store/store5/impl/DefaultLogger.kt
@@ -1,17 +1,15 @@
 package org.mobilenativefoundation.store.store5.impl
 
-import co.touchlab.kermit.CommonWriter
 import org.mobilenativefoundation.store.store5.Logger
 
 /**
  * Default implementation of [Logger] using the Kermit logging library.
+ *
+ * Derives a tagged logger from Kermit's global instance rather than reconfiguring it, so the host
+ * application's log writers and default tag are left untouched.
  */
 internal class DefaultLogger : Logger {
-    private val delegate =
-        co.touchlab.kermit.Logger.apply {
-            setLogWriters(listOf(CommonWriter()))
-            setTag("Store")
-        }
+    private val delegate = co.touchlab.kermit.Logger.withTag("Store")
 
     override fun debug(message: String) {
         delegate.d(message)

--- a/store/src/commonMain/kotlin/org/mobilenativefoundation/store/store5/impl/RealStore.kt
+++ b/store/src/commonMain/kotlin/org/mobilenativefoundation/store/store5/impl/RealStore.kt
@@ -15,7 +15,6 @@
  */
 package org.mobilenativefoundation.store.store5.impl
 
-import co.touchlab.kermit.CommonWriter
 import co.touchlab.kermit.Logger
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
@@ -367,10 +366,8 @@ internal class RealStore<Key : Any, Network : Any, Output : Any, Local : Any>(
     private fun fromMemCache(key: Key) = memCache?.getIfPresent(key)
 
     companion object {
-        private val logger =
-            Logger.apply {
-                setLogWriters(listOf(CommonWriter()))
-                setTag("Store")
-            }
+        // Derives a tagged logger instead of reconfiguring Kermit's global one, which would drop
+        // whatever log writers the host application installed.
+        private val logger = Logger.withTag("Store")
     }
 }


### PR DESCRIPTION
Closes #749

## Problem

`DefaultLogger` and `RealStore`'s companion both run this on `co.touchlab.kermit.Logger`:

```kotlin
Logger.apply {
    setLogWriters(listOf(CommonWriter()))
    setTag("Store")
}
```

That receiver is Kermit's **process-global** logger singleton, not a Store-scoped instance. So constructing a Store reconfigures logging for the **whole host app**:

- `setLogWriters(...)` **replaces** the global writer list, dropping any writer the host installed via `addLogWriter(...)` (crash-reporter breadcrumbs, file writers).
- `setTag("Store")` overwrites the global default tag, so unrelated host logs start appearing under `Store`.
- Because `withTag` shares the same `MutableLoggerConfig`, loggers the host derived earlier are affected too.

Hosts configure logging at startup and build Stores later, so this is the common ordering — Store construction silently wipes the host's logging setup, with no error.

## Fix

Replace both sites with `Logger.withTag("Store")` — Kermit's recommended way to make a tagged logger. It derives a logger sharing the host's config and mutates **no** global state.

**Intended behavior change (not a regression):** Store now routes its internal logs through whatever writers + `minSeverity` the host configured, instead of replacing them. On a host that configured nothing, the sink falls back to Kermit's `platformLogWriter()` (Logcat / os_log / `console.*` / stdout+stderr) — the conventional per-platform default. Sharing host config is the deliberate good-citizen choice so the host can route or silence Store's logs; the fully-isolated `Logger(loggerConfigInit(platformLogWriter()), "Store")` was the consciously-rejected alternative.

The change is a behavior-preserving swap to a documented Kermit API touching only internal classes; `apiCheck` (JVM + KLib ABI), `ktlint`, and `spotless` are unaffected.

## Type of change

Bug fix (non-breaking).

## Scope

Fix-only. The public `Logger` interface is still only injectable through the internal `RealMutableStore` constructor — pre-existing and orthogonal to this bug. A public `logger` seam on the builders would be a natural follow-up; happy to do it as a separate PR.