### PR TITLE
Release 5.1.0-alpha11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ### Thank you to all our wonderful contributors and users
 
+## [5.1.0-alpha11] (2026-08-28)
+
+**Bug Fixes**
+
+* Stop Store from reconfiguring the host app's global Kermit logger [#750](https://github.com/MobileNativeFoundation/Store/pull/750)
+
+**Improvements**
+
+* Build modernization: Gradle 9.5, AGP 9.2, Kotlin 2.3, and tooling updates [#736](https://github.com/MobileNativeFoundation/Store/pull/736)
+
 ## [5.1.0-alpha10] (2026-07-13)
 
 **Bug Fixes**
@@ -385,7 +395,9 @@ This is a first alpha release of Store ported to RxJava 2.
 * The change log for Store version 1.x can be
   found [here](https://github.com/NYTimes/Store/blob/develop/CHANGELOG.md).
 
-[Unreleased]: https://github.com/MobileNativeFoundation/Store/compare/5.1.0-alpha10...HEAD
+[Unreleased]: https://github.com/MobileNativeFoundation/Store/compare/5.1.0-alpha11...HEAD
+
+[5.1.0-alpha11]: https://github.com/MobileNativeFoundation/Store/releases/tag/5.1.0-alpha11
 
 [5.1.0-alpha10]: https://github.com/MobileNativeFoundation/Store/releases/tag/5.1.0-alpha10
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,7 +26,7 @@ kmmBridge = "1.2.1"
 ktlint = "1.8.0"
 kover = "0.9.9"
 #noinspection UnusedVersionCatalogEntry
-store = "5.1.0-SNAPSHOT"
+store = "5.1.0-alpha11"
 truth = "1.4.5"
 turbine = "1.2.1"
 binary-compatibility-validator = "0.18.1"


### PR DESCRIPTION
Bump the version from 5.1.0-SNAPSHOT to 5.1.0-alpha11 in `gradle/libs.versions.toml` — the single source of truth for the project version since #736 (`gradle.properties` and the convention plugin no longer carry their own copies) — and add the CHANGELOG entry for this release.

## Changes since 5.1.0-alpha10

**Bug Fixes**
- Stop Store from reconfiguring the host app's global Kermit logger #750

**Improvements**
- Build modernization: Gradle 9.5, AGP 9.2, Kotlin 2.3, and tooling updates #736

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release metadata only (version catalog and changelog); no library or runtime code changes in this diff.
> 
> **Overview**
> Prepares the **5.1.0-alpha11** release by moving the published version from `5.1.0-SNAPSHOT` to `5.1.0-alpha11` in `gradle/libs.versions.toml` (the project’s version source of truth).
> 
> **CHANGELOG** adds the **5.1.0-alpha11** (2026-08-28) section, calling out the Kermit global-logger fix ([#750](https://github.com/MobileNativeFoundation/Store/pull/750)) and build/tooling modernization ([#736](https://github.com/MobileNativeFoundation/Store/pull/736)), and updates the bottom **Unreleased** / release link targets for alpha11.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82cbb7ccb70de6b14f22ac25161eefd0ca69b7af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->